### PR TITLE
docs: 完善 clangd 工具链配置与文档

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,40 +1,142 @@
+# =============================================================================
+# .clang-format —— clang-format 代码格式化规则（YAML 格式）
+#
+# 作用范围：本文件所在目录及其所有子目录下的源文件
+# 加载方式：clang-format 向上递归查找最近一个 .clang-format 文件
+#          clangd 调用 clang-format 时也会自动读取
+# 触发时机：
+#   - 编辑器保存时格式化（VS Code: editor.formatOnSave）
+#   - 手动 Format Document / Format Selection
+#   - LSP textDocument/formatting 请求
+#   - clang-format CLI（pre-commit hook、CI）
+# 优先级 ：本文件 > clangd --fallback-style > clang-format 内置默认（LLVM）
+# 详细文档：https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# =============================================================================
+
 ---
+# -----------------------------------------------------------------------------
+# 基础风格 —— 在某个内置预设上做增量修改
+# -----------------------------------------------------------------------------
+# 可选预设：LLVM | Google | Chromium | Mozilla | WebKit | Microsoft | GNU
+# 下面其他选项都是在 Google 风格基础上的覆盖
 BasedOnStyle: Google
+
+# 语言：Cpp（含 C/C++/Objective-C++）| Java | JavaScript | Proto | TableGen 等
 Language: Cpp
+
+# 解析时使用的 C++ 标准：影响某些语法识别（如折叠表达式、concept）
+# 可选：c++03 | c++11 | c++14 | c++17 | c++20 | Latest | Auto
+# 注：这只影响 clang-format 的「解析」，不影响项目实际编译标准
 Standard: c++20
 
-IndentWidth: 4
-TabWidth: 4
-UseTab: Never
-ColumnLimit: 100
 
+# -----------------------------------------------------------------------------
+# 缩进与列宽
+# -----------------------------------------------------------------------------
+IndentWidth: 4              # 一级缩进 4 个空格（Google 默认 2，此处覆盖）
+TabWidth: 4                 # Tab 显示宽度（仅在 UseTab 非 Never 时生效）
+UseTab: Never               # 只用空格，不用 Tab（跨编辑器一致性最好）
+ColumnLimit: 100            # 每行最大宽度，超过会自动换行；0 表示不限
+
+
+# -----------------------------------------------------------------------------
+# 短结构是否允许写在单行
+# -----------------------------------------------------------------------------
+# 访问修饰符（public/private）相对类体的偏移：-4 表示反向缩进 4 列，与 class 对齐
 AccessModifierOffset: -4
+
+# 短函数单行：None | InlineOnly | Empty | Inline | All
+# Empty 表示只允许「空函数体」单行：void noop() {}
 AllowShortFunctionsOnASingleLine: Empty
+
+# 短 if 语句单行：Never 永远换行，禁止 if (x) return;
 AllowShortIfStatementsOnASingleLine: Never
+
+# 短循环单行：false 永远换行
 AllowShortLoopsOnASingleLine: false
+
+# 短 lambda 单行：None | Empty | Inline | All
+# All 允许任何短 lambda 单行：auto f = [](int x) { return x + 1; };
 AllowShortLambdasOnASingleLine: All
 
+
+# -----------------------------------------------------------------------------
+# 大括号与换行风格
+# -----------------------------------------------------------------------------
+# 大括号位置：Attach（附加在语句尾，K&R 风格）| Linux | Allman | GNU | Stroustrup 等
+# Attach: if (x) {     <-- 大括号紧跟
 BreakBeforeBraces: Attach
+
+# 构造函数初始化列表换行位置：BeforeColon | BeforeComma | AfterColon | AfterComma
+# BeforeColon: Foo(int x)
+#                  : x_(x)
+#                  , y_(0)
 BreakConstructorInitializers: BeforeColon
+
+# 继承列表换行位置：同上
+# BeforeColon: class Foo
+#                  : public Bar
+#                  , public Baz
 BreakInheritanceList: BeforeColon
 
+
+# -----------------------------------------------------------------------------
+# 指针与引用对齐
+# -----------------------------------------------------------------------------
+# 是否从代码中推导对齐风格：false 表示严格遵循下面的设置
 DerivePointerAlignment: false
+
+# 指针 * 靠左：int* p   （而非 int *p 或 int * p）
 PointerAlignment: Left
+
+# 引用 & 靠左：int& r
 ReferenceAlignment: Left
 
+
+# -----------------------------------------------------------------------------
+# 空格控制
+# -----------------------------------------------------------------------------
+# template 关键字后是否加空格：true 表示 template <typename T>
 SpaceAfterTemplateKeyword: true
+
+# C++11 列表初始化前是否加空格：false 表示 Foo{1, 2}（而非 Foo {1, 2}）
 SpaceBeforeCpp11BracedList: false
+
+# range-based for 的冒号前是否加空格：true 表示 for (auto x : v)
 SpaceBeforeRangeBasedForLoopColon: true
 
+
+# -----------------------------------------------------------------------------
+# include 头文件排序与分组
+# -----------------------------------------------------------------------------
+# include 块处理：Preserve（保留原样）| Merge（合并相邻块）| Regroup（按下列规则重排+分组）
+# Regroup 会自动按 IncludeCategories 重排，相同 Priority 的内部按字典序排
 IncludeBlocks: Regroup
+
+# include 分类规则：Priority 数字越小越靠前；同 Priority 内部按字典序
+# 当前分组：
+#   1. C++ 标准库（<iostream>, <vector>, <cstdint>...）
+#   2. 第三方/系统 .h/.hpp 头（<gtest/gtest.h>, <fmt/format.h>...）
+#   3. 项目本地头（"my_header.h"）
 IncludeCategories:
-  - Regex: '^<[a-z_]+>$'
+  - Regex: '^<[a-z_]+>$'      # 纯小写无后缀：标准库
     Priority: 1
-  - Regex: '^<.*\.h(pp)?>$'
+  - Regex: '^<.*\.h(pp)?>$'   # 尖括号 + .h/.hpp：第三方
     Priority: 2
-  - Regex: '^".*"$'
+  - Regex: '^".*"$'           # 双引号：项目本地
     Priority: 3
 
+# include 排序方式：Never | CaseSensitive | CaseInsensitive
+# CaseSensitive: 'A' 排在 'a' 前面（ASCII 序）
 SortIncludes: CaseSensitive
+
+
+# -----------------------------------------------------------------------------
+# 命名空间
+# -----------------------------------------------------------------------------
+# 自动在 namespace 闭合 } 后添加 // namespace foo 注释
 FixNamespaceComments: true
+
+# 命名空间内部缩进：None | Inner | All
+# None: namespace foo { 内部不额外缩进（避免深层嵌套时缩进过深）
 NamespaceIndentation: None

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,218 @@
+# =============================================================================
+# .clang-tidy —— clang-tidy 静态检查规则（YAML 格式）
+#
+# 作用范围：本文件所在目录及其所有子目录下的源文件
+# 加载方式：clang-tidy 向上递归查找最近一个 .clang-tidy 文件
+#          clangd 内嵌调用 clang-tidy 时也会自动读取（需 clangd --clang-tidy，默认开）
+# 触发时机：
+#   - 编辑器实时诊断（clangd 后台调用）
+#   - clang-tidy CLI 手动运行（CI、pre-commit hook）
+#   - run-clang-tidy.py 批量分析整个项目
+# 优先级 ：本文件 > .clangd 中的 Diagnostics.ClangTidy 配置
+# 详细文档：https://clang.llvm.org/extra/clang-tidy/
+# 全部检查：https://clang.llvm.org/extra/clang-tidy/checks/list.html
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Checks —— 启用/禁用的检查规则列表
+# -----------------------------------------------------------------------------
+# 语法：
+#   '*'                  匹配所有
+#   'foo-*'              启用 foo 模块下所有规则
+#   '-foo-bar'           禁用具体规则（前缀 '-'）
+#   规则按顺序处理，后面的覆盖前面的
+#
+# 常见模块前缀：
+#   bugprone-*           易出错代码模式（隐式转换、悬挂引用、未初始化等）
+#   cert-*               CERT C/C++ 安全编码规范
+#   clang-analyzer-*     Clang 静态分析器（数据流、内存）
+#   concurrency-*        多线程并发问题
+#   cppcoreguidelines-*  C++ Core Guidelines（Bjarne + Herb 主导）
+#   google-*             Google C++ Style Guide
+#   hicpp-*              High Integrity C++（嵌入式/安全关键）
+#   llvm-*               LLVM 项目自身风格
+#   misc-*               杂项（无法归类的）
+#   modernize-*          推荐 modern C++ 写法（nullptr / 范围 for / using 别名）
+#   performance-*        性能优化建议（不必要拷贝、低效字符串操作）
+#   portability-*        可移植性
+#   readability-*        可读性改进（命名、控制流复杂度、隐式 bool 转换）
+# -----------------------------------------------------------------------------
+Checks: >
+  bugprone-*,
+  cert-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-avoid-c-arrays,
+  -modernize-avoid-c-arrays,
+  -hicpp-avoid-c-arrays,
+  -bugprone-easily-swappable-parameters,
+  -cert-err58-cpp,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -misc-non-private-member-variables-in-classes
+
+
+# -----------------------------------------------------------------------------
+# WarningsAsErrors —— 哪些警告升级为错误（在 CI 中拦截合并）
+# -----------------------------------------------------------------------------
+# 留空表示不升级，开发期建议留空，CI 时通过 CLI 参数 --warnings-as-errors=* 强制
+# 示例：'bugprone-*,cert-*' 把这两类升级为错误
+WarningsAsErrors: ''
+
+
+# -----------------------------------------------------------------------------
+# HeaderFilterRegex —— 哪些头文件被分析（默认只分析当前 TU 的源文件）
+# -----------------------------------------------------------------------------
+# 正则匹配头文件路径。'.*' 匹配所有，但会大量分析三方库头，慢且噪音大
+# 推荐：只分析项目自己的头，匹配 modules/、include/、src/ 等目录
+HeaderFilterRegex: '^.*/(modules|include|src)/.*\.(h|hpp)$'
+
+
+# -----------------------------------------------------------------------------
+# FormatStyle —— clang-tidy --fix 修复后用什么风格格式化
+# -----------------------------------------------------------------------------
+# file 表示读取就近的 .clang-format 文件（推荐）
+# 也可以直接写 'Google' / 'LLVM' 等内置风格
+FormatStyle: file
+
+
+# -----------------------------------------------------------------------------
+# CheckOptions —— 各规则的细粒度参数
+# -----------------------------------------------------------------------------
+# 格式：key 是 "<check>.<option>"，value 是字符串
+# 完整选项见每个 check 的文档页
+# -----------------------------------------------------------------------------
+CheckOptions:
+  # ---- 命名规范（readability-identifier-naming）----
+  # 大小写风格可选：
+  #   lower_case | UPPER_CASE | camelBack | CamelCase | aNy_CasE
+  #   Leading_upper_snake_case | Camel_Snake_Case 等
+
+  # 命名空间：lower_case
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+
+  # 类/结构体/联合体：CamelCase
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+
+  # 枚举类型 + 枚举常量：CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+
+  # 函数：camelBack（如 doSomething）；可改为 lower_case 走 std 风格
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+
+  # 变量：lower_case
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+
+  # 类成员变量：lower_case + 后缀 _（Google 风格）
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: _
+
+  # 全局/静态常量：UPPER_CASE 或 kCamelCase（Google 风格用 k 前缀）
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: k
+
+  # 宏定义：UPPER_CASE
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+
+  # 模板参数：CamelCase（如 typename ValueType）
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+
+  # ---- 函数复杂度限制（readability-function-*） ----
+  # 函数行数上限（含空行/注释），超过会警告
+  - key: readability-function-size.LineThreshold
+    value: '120'
+  # 单函数语句数上限
+  - key: readability-function-size.StatementThreshold
+    value: '60'
+  # 函数参数个数上限
+  - key: readability-function-size.ParameterThreshold
+    value: '6'
+
+  # ---- 循环复杂度（readability-function-cognitive-complexity） ----
+  # 单函数认知复杂度上限（嵌套+控制流加权）
+  - key: readability-function-cognitive-complexity.Threshold
+    value: '25'
+
+  # ---- modernize-use-nullptr ----
+  # 哪些字面量被视为 NULL 可替换：自定义宏写在这里
+  - key: modernize-use-nullptr.NullMacros
+    value: 'NULL'
+
+  # ---- modernize-loop-convert ----
+  # 范围 for 的最小元素数（小数组保留传统 for 也合理）
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+
+  # ---- modernize-use-auto ----
+  # 仅对长类型替换为 auto（避免短类型如 int 被误改）
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '5'
+
+  # ---- performance-unnecessary-value-param ----
+  # 大对象按值传递的字节阈值，超过会建议改为 const& 传参
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: ''
+
+  # ---- bugprone-argument-comment ----
+  # 是否检查 /*param=*/ 风格的参数注释名是否匹配
+  - key: bugprone-argument-comment.StrictMode
+    value: '1'
+
+  # ---- cppcoreguidelines-special-member-functions ----
+  # 五法则检查：定义任一就要全定义
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: '1'   # 允许只定义 = default 析构函数（不强制全实现）
+
+  # ---- 异常相关 ----
+  # 允许的异常基类（noexcept 范围检查会用到）
+  - key: bugprone-exception-escape.IgnoredExceptions
+    value: ''
+
+
+# -----------------------------------------------------------------------------
+# AnalyzeTemporaryDtors —— 分析临时对象析构函数
+# -----------------------------------------------------------------------------
+# 已废弃，保留 false 即可
+AnalyzeTemporaryDtors: false
+
+
+# -----------------------------------------------------------------------------
+# UseColor —— 终端输出是否着色
+# -----------------------------------------------------------------------------
+UseColor: true

--- a/.clangd
+++ b/.clangd
@@ -1,35 +1,97 @@
+# =============================================================================
+# .clangd —— clangd 语言服务器的项目级配置（YAML 格式）
+#
+# 作用范围：本文件所在目录及其所有子目录下的源文件
+# 加载方式：clangd 启动时自动读取（需 --enable-config，clangd 11+ 默认开启）
+# 优先级 ：编辑器 CLI 参数（如 VS Code 的 clangd.arguments）> .clangd 文件
+# 详细文档：https://clangd.llvm.org/config
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# CompileFlags —— 控制 clangd 看到的编译命令
+# -----------------------------------------------------------------------------
 CompileFlags:
-  # clangd looks for compile_commands.json; by default it searches upward from
-  # the source file and picks the nearest build/ tree. If you use multiple
-  # presets, point this at the preset you actively develop against (or copy
-  # compile_commands.json to the repo root after configuring).
-  CompilationDatabase: build/gcc-debug
+  # 指定 compile_commands.json 所在目录（相对 .clangd 文件位置）
+  # 默认情况下 clangd 会从源文件向上递归找，但 build 目录不在源文件路径上，
+  # 因此必须显式指定。VS Code 的 --compile-commands-dir CLI 参数会覆盖此项。
+  # 切换 preset 时需要同步修改这一行。
+  CompilationDatabase: build/my-gcc-relwithdebinfo
+
+  # 追加到所有编译命令的 flag，对 compile_commands.json 中已有的文件也生效
+  # 主要作用：保护「不在 DB 中的文件」（如临时新建的 .cpp）也能拿到正确的标准
   Add:
-    - -std=c++23
-    - -Wall
-    - -Wextra
-    - -Wpedantic
+    - -std=c++23      # C++23 标准（与项目主线一致）
+    - -Wall           # 常用警告组
+    - -Wextra         # 额外警告
+    - -Wpedantic      # 严格 ISO 标准检查
 
+
+# -----------------------------------------------------------------------------
+# Completion —— 控制代码补全行为
+# -----------------------------------------------------------------------------
+Completion:
+  # 全作用域补全：写 cout 即使没引入 std:: 也建议 std::cout
+  # 配合 HeaderInsertion 还能自动补 #include <iostream>
+  # 副作用：补全列表更长，偶尔推荐到非预期同名符号
+  AllScopes: Yes
+
+  # 头文件插入策略：IWYU（Include What You Use）
+  # 用了某个符号就直接 include 它的来源头，不依赖其他头的间接传递
+  # 可选值：IWYU | NeverInsert
+  HeaderInsertion: IWYU
+
+
+# -----------------------------------------------------------------------------
+# Diagnostics —— 控制诊断（红线/黄线/quickfix）
+# -----------------------------------------------------------------------------
 Diagnostics:
-  ClangTidy:
-    Add:
-      - modernize-*
-      - performance-*
-      - bugprone-*
-      - readability-*
-      - cppcoreguidelines-*
-    Remove:
-      - modernize-use-trailing-return-type
-      - readability-identifier-length
-      - readability-magic-numbers
-      - cppcoreguidelines-avoid-magic-numbers
-      - cppcoreguidelines-pro-bounds-pointer-arithmetic
-      - cppcoreguidelines-pro-bounds-array-to-pointer-decay
+  # 缺失 include 警告：用了某符号但没直接 include 它的来源头时报警
+  # 配合 HeaderInsertion: IWYU 提供一键修复
+  # 大型项目或重度使用第三方库时可能产生噪音，按需关闭
+  MissingIncludes: Strict
 
+  # 多余 include 警告：include 了但没用到的头会被标记
+  # 提供 quickfix 一键删除
+  UnusedIncludes: Strict
+
+  # ---- clang-tidy 静态检查 ----
+  # 启用整组 + 关闭过严的具体规则，是社区主流做法
+  ClangTidy:
+    # 启用的规则组（* 通配匹配组下所有规则）
+    Add:
+      - modernize-*           # 推荐 modern C++ 写法（nullptr / 范围 for / using 别名等）
+      - performance-*         # 性能优化建议（不必要拷贝、低效字符串操作等）
+      - bugprone-*            # 易出错代码模式（隐式转换、悬挂引用、未初始化等）
+      - readability-*         # 可读性改进（命名、控制流复杂度、隐式 bool 转换等）
+      - cppcoreguidelines-*   # C++ Core Guidelines 强制规则
+
+    # 从启用组中关闭的具体规则（过严或与项目风格冲突）
+    Remove:
+      - modernize-use-trailing-return-type                       # 强制 auto func() -> int 写法，多数项目不爱用
+      - readability-identifier-length                            # 禁止单字母名（i/j/n），数学/循环里不实用
+      - readability-magic-numbers                                # 把所有字面量当魔法数（包括 0/1/2）
+      - cppcoreguidelines-avoid-magic-numbers                    # 同上
+      - cppcoreguidelines-pro-bounds-pointer-arithmetic          # 禁止指针算术，写底层代码不可避免
+      - cppcoreguidelines-pro-bounds-array-to-pointer-decay      # 禁止数组退化，C 风格 API 必须用
+
+
+# -----------------------------------------------------------------------------
+# Index —— 后台索引设置（用于跳转定义、查找引用、全局补全）
+# -----------------------------------------------------------------------------
 Index:
+  # 后台索引模式：Build（构建索引）| Skip（跳过）
+  # 通常配合 If.PathMatch 对 third_party 目录设 Skip 以节省资源
   Background: Build
 
+
+# -----------------------------------------------------------------------------
+# InlayHints —— 编辑器内联提示（VS Code 默认开，Neovim 需 vim.lsp.inlay_hint.enable(true)）
+# -----------------------------------------------------------------------------
 InlayHints:
-  Enabled: Yes
-  ParameterNames: Yes
-  DeducedTypes: Yes
+  Enabled: Yes              # 总开关
+  ParameterNames: Yes       # 函数调用处显示形参名：foo(/*x:*/ 1, /*y:*/ 2)
+  DeducedTypes: Yes         # auto 推导类型显示：auto x = ... ← /* int */
+  Designators: Yes          # 聚合初始化显示成员名：Point{/*.x=*/ 1, /*.y=*/ 2}
+  BlockEnd: Yes             # 长函数 } 后显示这是哪个块的收尾
+  DefaultArguments: Yes     # 调用时显示用到的默认参数值：foo(1) ← /*, y=10*/

--- a/docs/clang-format-config-guide.md
+++ b/docs/clang-format-config-guide.md
@@ -1,0 +1,531 @@
+# `.clang-format` 配置完整指南
+
+> 本文档面向当前 ModernCpp 项目（Windows + MinGW UCRT64 + CMake Presets），系统介绍 `.clang-format` 的所有常用配置项、典型场景与编辑器集成方式。
+>
+> 官方完整文档：https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+
+## 目录
+
+1. [clang-format 是什么](#1-clang-format-是什么)
+2. [配置文件加载规则](#2-配置文件加载规则)
+3. [基础风格预设（BasedOnStyle）](#3-基础风格预设basedonstyle)
+4. [核心配置项分类详解](#4-核心配置项分类详解)
+   - 4.1 [缩进与列宽](#41-缩进与列宽)
+   - 4.2 [大括号风格](#42-大括号风格)
+   - 4.3 [单行短结构](#43-单行短结构)
+   - 4.4 [对齐相关](#44-对齐相关)
+   - 4.5 [指针与引用](#45-指针与引用)
+   - 4.6 [空格控制](#46-空格控制)
+   - 4.7 [换行控制](#47-换行控制)
+   - 4.8 [include 排序与分组](#48-include-排序与分组)
+   - 4.9 [命名空间](#49-命名空间)
+   - 4.10 [注释](#410-注释)
+   - 4.11 [函数 / lambda / 模板](#411-函数--lambda--模板)
+   - 4.12 [现代 C++ 特性](#412-现代-c-特性)
+5. [按语言区分配置（Language 多段）](#5-按语言区分配置language-多段)
+6. [禁用范围（注释开关）](#6-禁用范围注释开关)
+7. [常见场景配方](#7-常见场景配方)
+8. [编辑器与 CI 集成](#8-编辑器与-ci-集成)
+9. [与 `.clangd` / `.clang-tidy` 的协作](#9-与-clangd--clang-tidy-的协作)
+10. [常见问题排查](#10-常见问题排查)
+
+---
+
+## 1. clang-format 是什么
+
+`clang-format` 是 LLVM 项目提供的 C/C++/Objective-C/Java/JavaScript/Proto 等多语言代码格式化工具。它读取项目中的 `.clang-format` 文件，按规则重排空白、换行、缩进、include 顺序，但**不会修改语义**。
+
+clangd LSP 在收到 `textDocument/formatting` 请求时，会调用 clang-format 完成实际格式化，因此**只要项目里有 `.clang-format`，VS Code / Neovim 等编辑器自动格式化就会按它来**。
+
+---
+
+## 2. 配置文件加载规则
+
+- **就近优先**：clang-format 从被格式化的源文件所在目录开始，**向上递归**寻找最近的 `.clang-format`（或 `_clang-format`）文件
+- **多文件分层**：子目录可以放自己的 `.clang-format` 完全覆盖父级，或用 `BasedOnStyle: InheritParentConfig` 增量继承
+- **找不到时**：使用 clang-format CLI 的 `--style=...` 或 clangd 的 `--fallback-style=...` 指定的内置风格；都没有就用 LLVM 默认
+- **行内禁用**：源代码中 `// clang-format off` / `// clang-format on` 之间的内容跳过格式化
+
+---
+
+## 3. 基础风格预设（BasedOnStyle）
+
+| 预设 | 风格特点 | 缩进 | 列宽 |
+|---|---|---|---|
+| **LLVM** | LLVM 项目自身风格 | 2 | 80 |
+| **Google** | Google C++ Style Guide | 2 | 80 |
+| **Chromium** | 基于 Google 微调 | 2 | 80 |
+| **Mozilla** | Firefox 项目 | 2 | 80 |
+| **WebKit** | Safari 引擎 | 4 | 不限 |
+| **Microsoft** | 微软风格（与 .NET 接近） | 4 | 120 |
+| **GNU** | GNU 项目（大括号 Allman） | 2 | 79 |
+| **InheritParentConfig** | 继承父级 .clang-format（用于子目录覆盖） | — | — |
+
+**用法**：先选一个最接近的预设，再用其它字段做覆盖。本项目选 `Google` + 4 空格缩进 + 100 列宽。
+
+```yaml
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+```
+
+---
+
+## 4. 核心配置项分类详解
+
+### 4.1 缩进与列宽
+
+| 选项 | 取值 | 说明 |
+|---|---|---|
+| `IndentWidth` | int | 一级缩进空格数 |
+| `TabWidth` | int | Tab 显示宽度 |
+| `UseTab` | `Never` / `ForIndentation` / `ForContinuationAndIndentation` / `Always` | 是否用 Tab |
+| `ColumnLimit` | int（0 = 不限） | 每行最大字符数 |
+| `ContinuationIndentWidth` | int | 续行缩进（默认 4） |
+| `ConstructorInitializerIndentWidth` | int | 构造函数初始化列表缩进 |
+| `AccessModifierOffset` | int（可负） | `public:` 等相对类体的偏移 |
+| `IndentCaseLabels` | bool | switch 的 case 是否额外缩进 |
+| `IndentPPDirectives` | `None` / `AfterHash` / `BeforeHash` | `#define` 等预处理指令缩进 |
+| `IndentWrappedFunctionNames` | bool | 长函数名换行后是否缩进 |
+| `NamespaceIndentation` | `None` / `Inner` / `All` | namespace 内是否缩进 |
+
+### 4.2 大括号风格
+
+| 选项 | 说明 |
+|---|---|
+| `BreakBeforeBraces` | 整体大括号风格：`Attach` / `Linux` / `Mozilla` / `Stroustrup` / `Allman` / `GNU` / `WebKit` / `Custom` |
+| `BraceWrapping` | `Custom` 时的细粒度控制（每种结构单独设是否换行） |
+
+`BraceWrapping` 子项（仅 `Custom` 生效）：
+
+```yaml
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      false   # class Foo {
+  AfterControlStatement: Never   # if (x) {
+  AfterEnum:       false
+  AfterFunction:   true    # void foo()\n{
+  AfterNamespace:  false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false   # } catch
+  BeforeElse:      false   # } else
+  BeforeLambdaBody: false
+  BeforeWhile:     false   # do {} while
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord:   false
+  SplitEmptyNamespace: false
+```
+
+### 4.3 单行短结构
+
+| 选项 | 取值 | 说明 |
+|---|---|---|
+| `AllowShortBlocksOnASingleLine` | `Never` / `Empty` / `Always` | 短代码块 `{ stmt; }` |
+| `AllowShortCaseLabelsOnASingleLine` | bool | `case 1: return;` |
+| `AllowShortEnumsOnASingleLine` | bool | `enum E {A, B};` |
+| `AllowShortFunctionsOnASingleLine` | `None` / `InlineOnly` / `Empty` / `Inline` / `All` | 短函数 |
+| `AllowShortIfStatementsOnASingleLine` | `Never` / `WithoutElse` / `OnlyFirstIf` / `AllIfsAndElse` | 短 if |
+| `AllowShortLambdasOnASingleLine` | `None` / `Empty` / `Inline` / `All` | 短 lambda |
+| `AllowShortLoopsOnASingleLine` | bool | 短 for/while |
+
+### 4.4 对齐相关
+
+| 选项 | 说明 |
+|---|---|
+| `AlignAfterOpenBracket` | `Align` / `DontAlign` / `AlwaysBreak` / `BlockIndent` —— 函数调用括号后参数是否对齐 |
+| `AlignArrayOfStructures` | `None` / `Left` / `Right` —— 结构体数组对齐 |
+| `AlignConsecutiveAssignments` | 连续赋值的 `=` 对齐 |
+| `AlignConsecutiveBitFields` | 连续位域对齐 |
+| `AlignConsecutiveDeclarations` | 连续变量声明对齐 |
+| `AlignConsecutiveMacros` | 连续 `#define` 对齐 |
+| `AlignEscapedNewlines` | `DontAlign` / `Left` / `Right` —— 宏中的 `\` 对齐 |
+| `AlignOperands` | `DontAlign` / `Align` / `AlignAfterOperator` —— 多行表达式操作数对齐 |
+| `AlignTrailingComments` | bool / 详细对象 —— 行尾注释对齐 |
+
+`AlignConsecutive*` 系列的可用对象写法：
+
+```yaml
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false   # 跨空行是否仍对齐
+  AcrossComments: false
+  AlignCompound: true       # +=, -= 也对齐
+  PadOperators: true
+```
+
+### 4.5 指针与引用
+
+| 选项 | 取值 | 效果 |
+|---|---|---|
+| `PointerAlignment` | `Left` / `Right` / `Middle` | `int*` / `int *` / `int * ` |
+| `ReferenceAlignment` | `Pointer` / `Left` / `Right` / `Middle` | `int&` / `int &` |
+| `DerivePointerAlignment` | bool | true 时从代码统计推导，覆盖上面两项 |
+
+### 4.6 空格控制
+
+| 选项 | 说明 |
+|---|---|
+| `SpaceAfterCStyleCast` | `(int)x` vs `(int) x` |
+| `SpaceAfterLogicalNot` | `!x` vs `! x` |
+| `SpaceAfterTemplateKeyword` | `template<>` vs `template <>` |
+| `SpaceAroundPointerQualifiers` | `Default` / `Before` / `After` / `Both` |
+| `SpaceBeforeAssignmentOperators` | bool |
+| `SpaceBeforeCpp11BracedList` | `Foo {1}` vs `Foo{1}` |
+| `SpaceBeforeCtorInitializerColon` | `Foo(): x()` vs `Foo() : x()` |
+| `SpaceBeforeInheritanceColon` | bool |
+| `SpaceBeforeParens` | `Never` / `ControlStatements` / `ControlStatementsExceptControlMacros` / `NonEmptyParentheses` / `Always` / `Custom` |
+| `SpaceBeforeRangeBasedForLoopColon` | bool |
+| `SpaceBeforeSquareBrackets` | bool |
+| `SpaceInEmptyBlock` | `{}` vs `{ }` |
+| `SpaceInEmptyParentheses` | `()` vs `( )` |
+| `SpacesBeforeTrailingComments` | int —— 行尾注释前空格数 |
+| `SpacesInAngles` | `Never` / `Always` / `Leave` —— `<T>` |
+| `SpacesInCStyleCastParentheses` | bool |
+| `SpacesInConditionalStatement` | bool —— `if ( x )` |
+| `SpacesInContainerLiterals` | bool |
+| `SpacesInParentheses` | bool |
+| `SpacesInSquareBrackets` | bool |
+
+### 4.7 换行控制
+
+| 选项 | 说明 |
+|---|---|
+| `AllowAllArgumentsOnNextLine` | 允许所有参数换到下一行 |
+| `AllowAllParametersOfDeclarationOnNextLine` | 同上但用于声明 |
+| `AlwaysBreakAfterReturnType` | `None` / `All` / `TopLevel` / `AllDefinitions` / `TopLevelDefinitions` |
+| `AlwaysBreakBeforeMultilineStrings` | bool |
+| `AlwaysBreakTemplateDeclarations` | `No` / `MultiLine` / `Yes` |
+| `BinPackArguments` | bool —— false 时每个实参单独一行 |
+| `BinPackParameters` | bool —— false 时每个形参单独一行 |
+| `BreakBeforeBinaryOperators` | `None` / `NonAssignment` / `All` |
+| `BreakBeforeConceptDeclarations` | `Never` / `Allowed` / `Always` |
+| `BreakBeforeTernaryOperators` | bool |
+| `BreakConstructorInitializers` | `BeforeColon` / `BeforeComma` / `AfterColon` |
+| `BreakInheritanceList` | 同上 |
+| `BreakStringLiterals` | bool —— 长字符串是否拆行 |
+| `MaxEmptyLinesToKeep` | int —— 连续空行最大数 |
+| `KeepEmptyLinesAtTheStartOfBlocks` | bool |
+
+### 4.8 include 排序与分组
+
+| 选项 | 说明 |
+|---|---|
+| `SortIncludes` | `Never` / `CaseSensitive` / `CaseInsensitive` |
+| `IncludeBlocks` | `Preserve` / `Merge` / `Regroup` |
+| `IncludeCategories` | 列表，按正则匹配指定 Priority |
+| `IncludeIsMainRegex` | 主源文件名正则（用于把 `foo.cc` 对应的 `foo.h` 放最上面） |
+| `IncludeIsMainSourceRegex` | 反向：主头文件名正则 |
+
+完整示例：
+
+```yaml
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^"(my_project)/'   # 项目内绝对路径
+    Priority: 1
+  - Regex: '^"'                # 其他双引号
+    Priority: 2
+  - Regex: '^<.*\.h(pp)?>'     # 三方库
+    Priority: 3
+  - Regex: '^<[a-z_]+>'        # 标准库
+    Priority: 4
+SortIncludes: CaseSensitive
+IncludeIsMainRegex: '(_test)?$'
+```
+
+### 4.9 命名空间
+
+| 选项 | 说明 |
+|---|---|
+| `FixNamespaceComments` | 自动加/修正 `// namespace foo` |
+| `NamespaceIndentation` | 内部缩进：`None` / `Inner` / `All` |
+| `CompactNamespaces` | `namespace A { namespace B {` 压成一行 |
+| `ShortNamespaceLines` | int —— 多短的 namespace 不加 // 注释 |
+
+### 4.10 注释
+
+| 选项 | 说明 |
+|---|---|
+| `ReflowComments` | 自动 reflow 长注释到 ColumnLimit |
+| `CommentPragmas` | 正则：匹配的注释不动（如 `IWYU pragma:`） |
+
+### 4.11 函数 / lambda / 模板
+
+| 选项 | 说明 |
+|---|---|
+| `LambdaBodyIndentation` | `Signature` / `OuterScope` |
+| `RequiresClausePosition` | `OwnLine` / `WithPreceding` / `WithFollowing` / `SingleLine` —— C++20 requires 子句位置 |
+| `RequiresExpressionIndentation` | `OuterScope` / `Keyword` |
+| `IndentRequiresClause` | bool |
+| `PackConstructorInitializers` | `Never` / `BinPack` / `CurrentLine` / `NextLine` |
+| `EmptyLineAfterAccessModifier` | `Never` / `Leave` / `Always` |
+| `EmptyLineBeforeAccessModifier` | 同上 |
+| `SeparateDefinitionBlocks` | `Leave` / `Always` / `Never` —— 函数/类定义之间是否强制空行 |
+
+### 4.12 现代 C++ 特性
+
+| 选项 | 说明 |
+|---|---|
+| `Cpp11BracedListStyle` | true 时按函数调用风格格式化列表初始化 |
+| `FixNamespaceComments` | 见上 |
+| `Standard` | `c++03` / `11` / `14` / `17` / `20` / `Latest` —— 解析时使用的标准 |
+| `AlwaysBreakTemplateDeclarations` | template<> 后是否强制换行 |
+| `BreakBeforeConceptDeclarations` | concept 前是否换行 |
+| `RequiresClausePosition` | requires 子句位置（C++20） |
+
+---
+
+## 5. 按语言区分配置（Language 多段）
+
+如果同一项目有 C++/Java/Proto 等多语言代码，可以在一个 `.clang-format` 里写多段：
+
+```yaml
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+
+---
+Language: Proto
+BasedOnStyle: Google
+IndentWidth: 2
+
+---
+Language: Java
+BasedOnStyle: Google
+ContinuationIndentWidth: 8
+```
+
+每段以 `---` 分隔，clang-format 根据文件后缀自动选择对应段。
+
+---
+
+## 6. 禁用范围（注释开关）
+
+源代码内可以局部关闭 / 打开格式化：
+
+```cpp
+// clang-format off
+const int magic_table[5][5] = {
+    { 1, 0, 0, 0, 0 },
+    { 0, 1, 0, 0, 0 },
+    { 0, 0, 1, 0, 0 },
+    { 0, 0, 0, 1, 0 },
+    { 0, 0, 0, 0, 1 },
+};
+// clang-format on
+```
+
+适用场景：手工对齐的表格、ASCII art、宏展开、特殊宽度的对齐代码。
+
+---
+
+## 7. 常见场景配方
+
+### 7.1 严格 80 列 + LLVM 风格
+
+```yaml
+BasedOnStyle: LLVM
+ColumnLimit: 80
+```
+
+### 7.2 偏 Qt / KDE 的 Allman 大括号
+
+```yaml
+BasedOnStyle: WebKit
+BreakBeforeBraces: Allman
+IndentWidth: 4
+```
+
+### 7.3 强制每个参数单独一行（适合参数多的工厂函数）
+
+```yaml
+BinPackParameters: false
+BinPackArguments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+```
+
+### 7.4 子目录覆盖父级
+
+```yaml
+# third_party/.clang-format
+BasedOnStyle: InheritParentConfig
+ColumnLimit: 0           # 三方代码不限列宽
+SortIncludes: Never      # 三方代码 include 顺序不动
+```
+
+### 7.5 头文件分组（与本项目一致）
+
+```yaml
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<[a-z_]+>$'      # 标准库
+    Priority: 1
+  - Regex: '^<.*\.h(pp)?>$'   # 三方
+    Priority: 2
+  - Regex: '^".*"$'           # 本地
+    Priority: 3
+SortIncludes: CaseSensitive
+```
+
+---
+
+## 8. 编辑器与 CI 集成
+
+### 8.1 VS Code
+
+settings.json：
+
+```json
+{
+  "editor.formatOnSave": true,
+  "[cpp]":   { "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd" },
+  "[c]":     { "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd" },
+  "clangd.arguments": [
+    "--fallback-style=Google"   // 找不到 .clang-format 时的兜底
+  ]
+}
+```
+
+### 8.2 Neovim (nvim-lspconfig + clangd)
+
+clangd 自带格式化能力，绑定保存时格式化即可：
+
+```lua
+vim.api.nvim_create_autocmd("BufWritePre", {
+  pattern = { "*.cpp", "*.hpp", "*.c", "*.h" },
+  callback = function() vim.lsp.buf.format({ async = false }) end,
+})
+```
+
+### 8.3 命令行
+
+```bash
+# 格式化单个文件（写回）
+clang-format -i src/foo.cpp
+
+# 检查未格式化的文件（CI）
+clang-format --dry-run --Werror src/**/*.cpp src/**/*.hpp
+
+# 用项目 .clang-format 验证
+git ls-files '*.cpp' '*.hpp' | xargs clang-format --dry-run --Werror
+```
+
+### 8.4 Git pre-commit hook
+
+```bash
+#!/usr/bin/env bash
+git diff --cached --name-only --diff-filter=ACM \
+  | grep -E '\.(cpp|hpp|h|cc|c)$' \
+  | xargs -r clang-format --dry-run --Werror
+```
+
+### 8.5 GitHub Actions
+
+```yaml
+- name: Check clang-format
+  run: |
+    sudo apt-get install -y clang-format
+    git ls-files '*.cpp' '*.hpp' | xargs clang-format --dry-run --Werror
+```
+
+---
+
+## 9. 与 `.clangd` / `.clang-tidy` 的协作
+
+`.clang-format` 只控制「格式」。它与另外两个配置文件分工如下：
+
+| 配置文件 | 关心什么 | 何时触发 |
+|---|---|---|
+| `.clang-format` | **怎么排版**（空白/换行/对齐/include 顺序） | 保存时格式化 |
+| `.clang-tidy`   | **代码逻辑/风格规则**（命名/魔法数/move 优化） | 编辑时实时诊断、CI |
+| `.clangd`       | **clangd LSP 自身行为**（要不要跑 tidy、提示样式） | clangd 启动时 |
+
+**触发链路**：
+
+```
+你保存文件
+   │
+   ▼
+编辑器 → clangd（textDocument/formatting）
+                │
+                └─ 调用 clang-format 读取 .clang-format → 返回格式化结果
+```
+
+```
+你编辑代码
+   │
+   ▼
+编辑器 → clangd（持续诊断）
+                │
+                ├─ 编译诊断（基于 compile_commands.json）
+                └─ clang-tidy 诊断（读取 .clang-tidy） → 红线/quickfix
+```
+
+详见 [`clangd-config-guide.md`](./clangd-config-guide.md) 的「整体框架」一节。
+
+---
+
+## 10. 常见问题排查
+
+### Q1: 保存时没有自动格式化
+
+- 检查 VS Code `editor.formatOnSave: true`
+- 检查 `[cpp]` 区是否设置了 `defaultFormatter` 为 `llvm-vs-code-extensions.vscode-clangd`
+- 确认有装 clangd 插件而非 ms-vscode.cpptools
+
+### Q2: 部分文件被忽略
+
+- 检查 `.gitignore` / `.clangd-format` 文件名拼写（注意是 `.clang-format` 不是 `.clang_format`）
+- 检查文件后缀是否被 clang-format 识别（`.cppm` 等模块文件需要更新工具链）
+
+### Q3: 想看当前规则下某段代码会被改成什么
+
+```bash
+clang-format -style=file < src/foo.cpp | diff -u src/foo.cpp -
+```
+
+### Q4: 生成 yaml 表示当前内置风格
+
+```bash
+clang-format -style=Google -dump-config
+```
+
+把这个输出作为起点，删掉默认值后只保留覆盖项即可。
+
+### Q5: 格式化和 `.clang-tidy` 修复冲突
+
+`.clang-tidy` 中设置 `FormatStyle: file`，这样 `clang-tidy --fix` 会调用 clang-format 用项目规则收尾。
+
+### Q6: 想为某个目录单独定一套规则
+
+```
+project/
+├── .clang-format            # BasedOnStyle: Google
+├── src/
+│   └── (使用顶层规则)
+└── third_party/
+    └── .clang-format        # BasedOnStyle: InheritParentConfig + ColumnLimit: 0
+```
+
+---
+
+## 附：本项目当前配置回顾
+
+```yaml
+BasedOnStyle: Google      # 起点
+IndentWidth: 4            # 4 空格缩进（Google 默认 2）
+ColumnLimit: 100          # 100 列（Google 默认 80）
+PointerAlignment: Left    # int* p
+BreakBeforeBraces: Attach # K&R 风格
+NamespaceIndentation: None
+IncludeBlocks: Regroup    # 自动分组排序
+SortIncludes: CaseSensitive
+FixNamespaceComments: true
+```
+
+如果你想切换为 LLVM / Microsoft / Allman 风格，只需要改 `BasedOnStyle` 和 `BreakBeforeBraces`，其余项 clang-format 会自动用预设默认值填充。

--- a/docs/clang-tidy-config-guide.md
+++ b/docs/clang-tidy-config-guide.md
@@ -1,0 +1,587 @@
+# `.clang-tidy` 配置完整指南
+
+> 本文档系统介绍 clang-tidy 静态检查规则、`.clang-tidy` 的所有顶层字段、常用 check 模块、CheckOptions 配置以及与 clangd / CI 的集成。
+>
+> 官方文档：https://clang.llvm.org/extra/clang-tidy/
+> 全部 check 列表：https://clang.llvm.org/extra/clang-tidy/checks/list.html
+
+---
+
+## 目录
+
+1. [clang-tidy 是什么](#1-clang-tidy-是什么)
+2. [配置文件加载规则](#2-配置文件加载规则)
+3. [`.clang-tidy` 顶层字段](#3-clang-tidy-顶层字段)
+4. [Checks 表达式语法](#4-checks-表达式语法)
+5. [Check 模块全览](#5-check-模块全览)
+6. [关键 check 详解](#6-关键-check-详解)
+7. [CheckOptions 细粒度参数](#7-checkoptions-细粒度参数)
+8. [命名规范（readability-identifier-naming）](#8-命名规范readability-identifier-naming)
+9. [按目录分层覆盖](#9-按目录分层覆盖)
+10. [行内禁用与 NOLINT](#10-行内禁用与-nolint)
+11. [与 `.clangd` 的关系](#11-与-clangd-的关系)
+12. [命令行使用](#12-命令行使用)
+13. [CI 集成](#13-ci-集成)
+14. [常见问题](#14-常见问题)
+
+---
+
+## 1. clang-tidy 是什么
+
+`clang-tidy` 是基于 Clang AST 的 C/C++ 静态分析与现代化重构工具。它不仅能发现潜在 bug，还能自动 `--fix` 替换代码（如 `NULL → nullptr`、传统 for → 范围 for、`typedef → using`）。
+
+clangd LSP 在打开 C++ 文件时会**内嵌**调用 clang-tidy（行为受 clangd `--clang-tidy` 控制，默认开），把 tidy 警告作为 LSP 诊断显示在编辑器中。
+
+---
+
+## 2. 配置文件加载规则
+
+- **就近优先**：clang-tidy 从被检查文件所在目录**向上递归**寻找最近的 `.clang-tidy`
+- **分层继承**：默认子目录的 `.clang-tidy` 是「替换」父级。要继承，使用 `InheritParentConfig: true`
+- **多份配置**：可以让 `tests/`、`third_party/` 各自有更宽松的配置
+- **CLI 覆盖**：`clang-tidy --checks=...` 会与文件中的 Checks 合并
+
+---
+
+## 3. `.clang-tidy` 顶层字段
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `Checks` | string | 启用/禁用规则的逗号分隔表达式 |
+| `WarningsAsErrors` | string | 哪些警告升级为错误（同 Checks 语法） |
+| `HeaderFilterRegex` | regex | 哪些头文件被分析（默认只分析当前 TU 的源） |
+| `ExcludeHeaderFilterRegex` | regex | 头文件排除模式（clang-tidy 17+） |
+| `FormatStyle` | string | `--fix` 后用什么风格格式化：`file` / `Google` / `LLVM` / `none` |
+| `User` | string | NOLINT 注释的作者标记 |
+| `CheckOptions` | list/dict | 各 check 的细粒度参数 |
+| `SystemHeaders` | bool | 是否分析系统头（一般 false） |
+| `InheritParentConfig` | bool | 是否继承父目录的 .clang-tidy |
+| `UseColor` | bool | 终端着色 |
+| `AnalyzeTemporaryDtors` | bool | 已废弃 |
+
+**最小可用配置**：
+
+```yaml
+Checks: 'modernize-*,bugprone-*,readability-*,-readability-magic-numbers'
+HeaderFilterRegex: '^.*/(src|include)/.*\.(h|hpp)$'
+FormatStyle: file
+```
+
+---
+
+## 4. Checks 表达式语法
+
+| 语法 | 含义 |
+|---|---|
+| `*` | 启用所有 check |
+| `foo-*` | 启用 foo 模块下所有 check |
+| `foo-bar` | 启用具体 check |
+| `-foo-bar` | 禁用具体 check（前缀 `-`） |
+| `-foo-*` | 禁用整个模块 |
+| `*,-foo-*` | 启用所有，再排除 foo |
+
+**多行写法**（YAML block scalar）：
+
+```yaml
+Checks: >
+  modernize-*,
+  performance-*,
+  -modernize-use-trailing-return-type,
+  -performance-no-int-to-ptr
+```
+
+**重要**：表达式按顺序解析，**后面的覆盖前面的**。所以 `*,-modernize-*` 会启用所有再关掉 modernize；而 `-modernize-*,*` 等于全启用（被 `*` 覆盖）。
+
+---
+
+## 5. Check 模块全览
+
+| 模块 | 数量 | 用途 |
+|---|---|---|
+| **abseil-** | ~20 | Abseil 库使用规范 |
+| **altera-** | ~5 | OpenCL FPGA 相关 |
+| **android-** | ~10 | Android NDK 编程 |
+| **boost-** | ~5 | Boost 库使用 |
+| **bugprone-** | ~80 | **易出错代码模式** |
+| **cert-** | ~30 | CERT C/C++ 安全编码 |
+| **clang-analyzer-** | ~120 | Clang 静态分析器 |
+| **concurrency-** | ~3 | 并发问题 |
+| **cppcoreguidelines-** | ~50 | **C++ Core Guidelines** |
+| **darwin-** | ~2 | macOS 平台 |
+| **fuchsia-** | ~10 | Fuchsia OS |
+| **google-** | ~20 | **Google C++ Style Guide** |
+| **hicpp-** | ~30 | High Integrity C++ |
+| **linuxkernel-** | ~2 | Linux 内核风格 |
+| **llvm-** | ~20 | LLVM 项目 |
+| **llvmlibc-** | ~5 | LLVM libc |
+| **misc-** | ~20 | 杂项 |
+| **modernize-** | ~40 | **现代 C++ 现代化** |
+| **mpi-** | ~3 | MPI 并行 |
+| **objc-** | ~10 | Objective-C |
+| **openmp-** | ~3 | OpenMP 并行 |
+| **performance-** | ~30 | **性能优化** |
+| **portability-** | ~5 | 可移植性 |
+| **readability-** | ~50 | **可读性** |
+| **zircon-** | ~1 | Zircon 内核 |
+
+**通用项目最常用的 6 组**：
+
+```yaml
+Checks: >
+  bugprone-*,
+  cert-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  performance-*,
+  readability-*
+```
+
+---
+
+## 6. 关键 check 详解
+
+### 6.1 modernize-（推荐 modern C++）
+
+| Check | 作用 |
+|---|---|
+| `modernize-use-nullptr` | `NULL` / `0` → `nullptr` |
+| `modernize-use-auto` | 长类型 → `auto` |
+| `modernize-use-using` | `typedef` → `using` |
+| `modernize-use-default-member-init` | 类成员就地初始化 |
+| `modernize-use-equals-default` | `Foo() {}` → `Foo() = default;` |
+| `modernize-use-equals-delete` | 私有未实现 → `= delete` |
+| `modernize-loop-convert` | 传统 for → 范围 for |
+| `modernize-make-unique` / `make-shared` | `new T` → `make_unique<T>` |
+| `modernize-use-emplace` | `push_back(T(...))` → `emplace_back(...)` |
+| `modernize-pass-by-value` | 大对象参数 → 按值 + std::move |
+| `modernize-use-trailing-return-type` | `int f()` → `auto f() -> int`（**通常关闭**） |
+| `modernize-use-nodiscard` | 给查询函数加 `[[nodiscard]]` |
+| `modernize-concat-nested-namespaces` | C++17 合并嵌套 namespace |
+| `modernize-use-designated-initializers` | C++20 指定初始化器 |
+
+### 6.2 performance-
+
+| Check | 作用 |
+|---|---|
+| `performance-unnecessary-copy-initialization` | 不必要的拷贝构造 |
+| `performance-unnecessary-value-param` | 大对象按值传参 → const& |
+| `performance-move-const-arg` | `std::move(const T)` 无效 move |
+| `performance-for-range-copy` | for 循环中 `auto x` 拷贝 → `const auto&` |
+| `performance-implicit-conversion-in-loop` | 隐式转换造成临时对象 |
+| `performance-inefficient-string-concatenation` | `s = s + ...` → `s += ...` |
+| `performance-noexcept-move-constructor` | move ctor 应 noexcept |
+| `performance-trivially-destructible` | 可平凡析构的类应去掉 dtor |
+
+### 6.3 bugprone-
+
+| Check | 作用 |
+|---|---|
+| `bugprone-use-after-move` | move 后再次使用对象 |
+| `bugprone-dangling-handle` | string_view/span 悬挂 |
+| `bugprone-narrowing-conversions` | 隐式窄化（int → short） |
+| `bugprone-undefined-memory-manipulation` | 对非 POD 类型 memcpy/memset |
+| `bugprone-string-integer-assignment` | `string = int`（隐式转 char） |
+| `bugprone-suspicious-semicolon` | 可疑的孤立分号 |
+| `bugprone-branch-clone` | if/else 分支体相同 |
+| `bugprone-easily-swappable-parameters` | 同类型相邻参数易被调反（**常关**） |
+| `bugprone-exception-escape` | noexcept 函数中可能抛异常 |
+
+### 6.4 cppcoreguidelines-
+
+| Check | 作用 |
+|---|---|
+| `cppcoreguidelines-pro-type-cstyle-cast` | 禁 C 风格 cast |
+| `cppcoreguidelines-pro-type-reinterpret-cast` | 禁 reinterpret_cast |
+| `cppcoreguidelines-pro-bounds-pointer-arithmetic` | 禁指针算术（**底层代码常关**） |
+| `cppcoreguidelines-special-member-functions` | 五法则（定义任一就要全定义） |
+| `cppcoreguidelines-init-variables` | 局部变量必须初始化 |
+| `cppcoreguidelines-avoid-magic-numbers` | 魔法数（**常关**） |
+| `cppcoreguidelines-owning-memory` | 用 `gsl::owner` 标注所有权 |
+| `cppcoreguidelines-rvalue-reference-param-not-moved` | && 参数没 move 也没 forward |
+
+### 6.5 readability-
+
+| Check | 作用 |
+|---|---|
+| `readability-identifier-naming` | **命名规范**（详见第 8 节） |
+| `readability-function-size` | 函数行数/复杂度 |
+| `readability-function-cognitive-complexity` | 认知复杂度 |
+| `readability-magic-numbers` | 魔法数（**常关**） |
+| `readability-implicit-bool-conversion` | 隐式 bool 转换 |
+| `readability-named-parameter` | 函数声明必须有形参名 |
+| `readability-redundant-*` | 各种冗余写法 |
+| `readability-simplify-boolean-expr` | bool 表达式简化 |
+| `readability-uppercase-literal-suffix` | `1.0f` 而非 `1.0F`（或反过来） |
+| `readability-container-size-empty` | `v.size() == 0` → `v.empty()` |
+| `readability-else-after-return` | return 后的 else 多余 |
+| `readability-qualified-auto` | `auto*` 而非 `auto` 拿指针 |
+
+### 6.6 cert-
+
+CERT 安全编码部分常用：
+
+| Check | 等价 |
+|---|---|
+| `cert-dcl21-cpp` | 后置自增运算符返回 const |
+| `cert-dcl50-cpp` | 不要定义 C 风格变参函数 |
+| `cert-err58-cpp` | 全局变量构造可能抛异常（**常关**） |
+| `cert-err60-cpp` | 异常类型应可拷贝且 noexcept |
+| `cert-flp30-c` | float 不要用作 for 循环计数 |
+| `cert-msc51-cpp` | 不要用 `std::rand()`，用 `<random>` |
+
+### 6.7 google-
+
+| Check | 作用 |
+|---|---|
+| `google-readability-braces-around-statements` | 单语句必须加大括号 |
+| `google-readability-namespace-comments` | namespace 闭合加注释 |
+| `google-explicit-constructor` | 单参数构造必须 explicit |
+| `google-build-using-namespace` | 头文件中禁止 `using namespace` |
+| `google-runtime-int` | 用 int32_t / int64_t 而非 short/long |
+
+### 6.8 concurrency-
+
+| Check | 作用 |
+|---|---|
+| `concurrency-mt-unsafe` | 调用 MT-unsafe 的 C 函数（如 `localtime`） |
+
+---
+
+## 7. CheckOptions 细粒度参数
+
+`CheckOptions` 是 list 形式（旧版）或 dict 形式（新版），key 形如 `<check>.<option>`：
+
+```yaml
+CheckOptions:
+  # list 形式（兼容性最好）
+  - key: readability-function-size.LineThreshold
+    value: '120'
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+
+  # dict 形式（clang-tidy 15+）
+  readability-function-size.StatementThreshold: '60'
+```
+
+**常用参数速查**：
+
+| Check.Option | 默认 | 说明 |
+|---|---|---|
+| `readability-function-size.LineThreshold` | none | 函数行数上限 |
+| `readability-function-size.StatementThreshold` | 800 | 语句数上限 |
+| `readability-function-size.ParameterThreshold` | none | 参数数上限 |
+| `readability-function-size.NestingThreshold` | none | 嵌套深度上限 |
+| `readability-function-cognitive-complexity.Threshold` | 25 | 认知复杂度上限 |
+| `modernize-loop-convert.MinConfidence` | reasonable | safe / reasonable / risky |
+| `modernize-use-auto.MinTypeNameLength` | 5 | 类型名 ≥ 多长才替换 |
+| `modernize-use-auto.RemoveStars` | false | 替换时是否吃掉 `*` |
+| `modernize-use-nullptr.NullMacros` | NULL | 等价 NULL 的宏列表 |
+| `performance-unnecessary-value-param.AllowedTypes` | '' | 允许按值传的类型正则 |
+| `performance-for-range-copy.WarnOnAllAutoCopies` | false | 即使 trivial 类型也警告 |
+| `cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor` | false | 允许只 default 析构函数 |
+| `cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions` | false | 允许缺 move 操作 |
+| `bugprone-argument-comment.StrictMode` | 0 | 是否强制 `/*x=*/` 注释名匹配 |
+| `bugprone-easily-swappable-parameters.MinimumLength` | 2 | 最小相邻同类型参数数 |
+| `misc-include-cleaner.IgnoreHeaders` | '' | 排除的头正则 |
+
+---
+
+## 8. 命名规范（readability-identifier-naming）
+
+可设的实体（**约 50 种**）：
+
+```
+ClassCase / StructCase / UnionCase / EnumCase / EnumConstantCase
+NamespaceCase / TypeAliasCase / TypedefCase
+FunctionCase / MemberFunctionCase / ClassMethodCase
+VariableCase / ParameterCase / LocalVariableCase
+GlobalVariableCase / StaticVariableCase
+MemberCase / PrivateMemberCase / ProtectedMemberCase / PublicMemberCase
+ConstantCase / GlobalConstantCase / LocalConstantCase / StaticConstantCase
+ConstexprFunctionCase / ConstexprVariableCase / ConstexprMethodCase
+MacroDefinitionCase
+TemplateParameterCase / TypeTemplateParameterCase / ValueTemplateParameterCase
+```
+
+每个实体都可设 4 个属性：
+
+| 后缀 | 含义 | 示例 |
+|---|---|---|
+| `.Case` | 大小写风格 | `lower_case` / `CamelCase` |
+| `.Prefix` | 前缀 | `k`（常量）/ `m_`（成员） |
+| `.Suffix` | 后缀 | `_`（私有成员） |
+| `.IgnoredRegexp` | 不检查的正则 | `^[A-Z]_test$` |
+
+可用风格值：
+
+| 值 | 示例 |
+|---|---|
+| `lower_case` | `do_something` |
+| `UPPER_CASE` | `MAX_SIZE` |
+| `camelBack` | `doSomething` |
+| `CamelCase` | `DoSomething` |
+| `Camel_Snake_Case` | `Do_Something` |
+| `aNy_CasE` | 不检查大小写 |
+| `Leading_upper_snake_case` | `Do_something` |
+
+**Google 风格示例**：
+
+```yaml
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,        value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,            value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase,         value: CamelCase }
+  - { key: readability-identifier-naming.VariableCase,         value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberCase,    value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,  value: _ }
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix, value: k }
+  - { key: readability-identifier-naming.MacroDefinitionCase,  value: UPPER_CASE }
+```
+
+**LLVM 风格示例**：
+
+```yaml
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,    value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.VariableCase, value: CamelCase }
+```
+
+---
+
+## 9. 按目录分层覆盖
+
+典型布局：
+
+```
+project/
+├── .clang-tidy                # 主配置（严格）
+├── src/                       # 用主配置
+├── tests/
+│   └── .clang-tidy            # 测试代码放宽
+└── third_party/
+    └── .clang-tidy            # 三方代码几乎全关
+```
+
+**测试代码放宽示例**：
+
+```yaml
+# tests/.clang-tidy
+InheritParentConfig: true
+Checks: >
+  -readability-function-cognitive-complexity,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-owning-memory,
+  -bugprone-exception-escape
+CheckOptions:
+  - key: readability-function-size.LineThreshold
+    value: '300'
+```
+
+**三方目录关掉所有检查**：
+
+```yaml
+# third_party/.clang-tidy
+Checks: '-*'
+```
+
+---
+
+## 10. 行内禁用与 NOLINT
+
+源代码中可以局部关闭某些 tidy 检查：
+
+```cpp
+// 关闭所有 check（仅当前行）
+int x = 0xdeadbeef;  // NOLINT
+
+// 关闭具体 check（仅当前行）
+int y = 42;  // NOLINT(readability-magic-numbers)
+
+// 关闭多个 check
+int z = 0;  // NOLINT(readability-magic-numbers, cppcoreguidelines-init-variables)
+
+// 关闭下一行
+// NOLINTNEXTLINE(modernize-use-nullptr)
+int *p = NULL;
+
+// 关闭一段范围
+// NOLINTBEGIN(readability-magic-numbers)
+const int table[] = {1, 2, 3, 5, 8, 13, 21};
+// NOLINTEND(readability-magic-numbers)
+```
+
+**最佳实践**：始终注明被关掉的具体 check 名，方便审计。
+
+---
+
+## 11. 与 `.clangd` 的关系
+
+`.clangd` 中的 `Diagnostics.ClangTidy` 子项：
+
+```yaml
+Diagnostics:
+  ClangTidy:
+    Add:    [modernize-*, performance-*]
+    Remove: [modernize-use-trailing-return-type]
+    CheckOptions:
+      readability-function-size.LineThreshold: '120'
+```
+
+**优先级**：
+
+```
+.clang-tidy（项目根/向上递归找的最近文件）
+        ▲ 覆盖
+.clangd 中的 Diagnostics.ClangTidy
+```
+
+也就是说：
+
+- **没有 `.clang-tidy`** → 用 `.clangd` 里写的 ClangTidy 配置
+- **有 `.clang-tidy`** → 以它为准，`.clangd` 里的 ClangTidy 配置基本被忽略
+
+**推荐做法**：把所有 tidy 规则集中在 `.clang-tidy`，`.clangd` 里只留一句 `ClangTidy:` 启用即可（或者完全省略，clangd 默认会跑 tidy）。
+
+---
+
+## 12. 命令行使用
+
+```bash
+# 检查单个文件（自动找 compile_commands.json）
+clang-tidy -p build/my-gcc-relwithdebinfo src/foo.cpp
+
+# 自动修复
+clang-tidy -p build/my-gcc-relwithdebinfo --fix src/foo.cpp
+
+# 只跑特定 check（覆盖 .clang-tidy）
+clang-tidy --checks='-*,bugprone-*' src/foo.cpp
+
+# 把警告升级为错误
+clang-tidy --warnings-as-errors='*' src/foo.cpp
+
+# 看当前生效的配置
+clang-tidy --dump-config
+
+# 看某个 check 的所有选项
+clang-tidy --checks=readability-function-size --dump-config
+
+# 批量分析（LLVM 自带脚本）
+run-clang-tidy.py -p build/my-gcc-relwithdebinfo \
+  -header-filter='^.*/(src|include)/.*' \
+  src/
+
+# 并行 + 修复
+run-clang-tidy.py -p build/my-gcc-relwithdebinfo -fix
+```
+
+---
+
+## 13. CI 集成
+
+### 13.1 GitHub Actions
+
+```yaml
+- name: clang-tidy
+  run: |
+    sudo apt-get install -y clang-tidy
+    cmake --preset my-gcc-relwithdebinfo
+    cmake --build build/my-gcc-relwithdebinfo
+    git ls-files 'modules/**/*.cpp' \
+      | xargs clang-tidy -p build/my-gcc-relwithdebinfo --warnings-as-errors='*'
+```
+
+### 13.2 只检查 PR 改动的文件
+
+```bash
+git diff --name-only origin/main...HEAD \
+  | grep -E '\.(cpp|hpp|h)$' \
+  | xargs -r clang-tidy -p build/my-gcc-relwithdebinfo
+```
+
+### 13.3 pre-commit hook
+
+```bash
+#!/usr/bin/env bash
+files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cpp|hpp|h)$')
+[ -z "$files" ] && exit 0
+clang-tidy -p build/my-gcc-relwithdebinfo --warnings-as-errors='*' $files
+```
+
+---
+
+## 14. 常见问题
+
+### Q1: 编辑器里没有 tidy 警告
+
+- 确认 `.clangd` 里没有显式 `ClangTidy: { Add: [] }` 全清空
+- 确认 clangd 启动参数没有 `--clang-tidy=false`
+- 确认 `compile_commands.json` 路径正确（tidy 需要它）
+- 重启 clangd（VS Code: `clangd: Restart language server`）
+
+### Q2: 警告太多，怎么逐步推行
+
+```yaml
+# 先启动一小组
+Checks: 'modernize-use-nullptr,modernize-use-auto'
+# 之后逐步增加
+```
+
+或用 NOLINT 标记现有违规，再用 CI 拦截新增。
+
+### Q3: 三方头被分析
+
+- 设置 `HeaderFilterRegex` 只匹配项目路径
+- 设置 `SystemHeaders: false`（默认）
+- 三方目录加一份 `.clang-tidy` 写 `Checks: '-*'`
+
+### Q4: `--fix` 把代码改坏了
+
+- `--fix` 是激进操作，先 commit 再跑
+- 用 `--fix-errors` 只在错误级别修复
+- 用 `--fix-notes` 包含关联 note
+
+### Q5: 命名规范报警太多
+
+- 旧项目可以先关掉 `readability-identifier-naming`，新代码逐步启用
+- 用 `IgnoredRegexp` 跳过历史命名
+
+### Q6: clangd 内嵌的 tidy 和 CI 用的版本不一致
+
+- 检查 clangd 版本（`clangd --version`）和 clang-tidy 版本（`clang-tidy --version`）
+- 不同版本支持的 check 集合不同，新 check 用旧 tidy 会报错
+- 建议在 CI 中用与本地 clangd 同版本的 clang-tidy
+
+### Q7: 想看哪些 check 是默认开启的
+
+```bash
+clang-tidy --list-checks         # 当前配置启用的
+clang-tidy --list-checks -checks='*'  # 所有可用的
+```
+
+---
+
+## 附：本项目当前配置回顾
+
+```yaml
+Checks: >
+  bugprone-*, cert-*, concurrency-*,
+  cppcoreguidelines-*, modernize-*,
+  performance-*, portability-*, readability-*,
+  -modernize-use-trailing-return-type,
+  -readability-magic-numbers,
+  ... (其他 ergonomic 关闭项)
+
+HeaderFilterRegex: '^.*/(modules|include|src)/.*\.(h|hpp)$'
+FormatStyle: file
+
+CheckOptions:
+  - readability-identifier-naming.*  → Google 风格
+  - readability-function-size.LineThreshold: 120
+  - readability-function-cognitive-complexity.Threshold: 25
+  - modernize-use-auto.MinTypeNameLength: 5
+  - cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: 1
+```
+
+如需更严，把 `WarningsAsErrors: 'bugprone-*,cert-*'` 打开。如需更宽松，按目录加子级 `.clang-tidy`。

--- a/docs/clangd-config-guide.md
+++ b/docs/clangd-config-guide.md
@@ -1,0 +1,923 @@
+# clangd 配置完全指南
+
+> 面向本项目（Windows + MinGW UCRT64 + vcpkg + CMake Presets）的实战手册。
+> 同时适用于 VS Code、Neovim、Emacs、Sublime、CLion 等所有支持 LSP 的编辑器。
+
+---
+
+## 目录
+
+- [1. 概述：clangd 是什么](#1-概述clangd-是什么)
+- [2. 配置层级与优先级](#2-配置层级与优先级)
+- [3. `.clangd` 文件加载规则](#3-clangd-文件加载规则)
+- [4. 完整配置项参考](#4-完整配置项参考)
+  - [4.1 `CompileFlags`](#41-compileflags)
+  - [4.2 `Completion`](#42-completion)
+  - [4.3 `Diagnostics`](#43-diagnostics)
+  - [4.4 `Index`](#44-index)
+  - [4.5 `InlayHints`](#45-inlayhints)
+  - [4.6 `Hover`](#46-hover)
+  - [4.7 `SemanticTokens`](#47-semantictokens)
+  - [4.8 `Style`](#48-style)
+  - [4.9 `If` —— 条件配置](#49-if--条件配置)
+- [5. clangd CLI 参数（编辑器侧）](#5-clangd-cli-参数编辑器侧)
+- [6. 与编辑器插件的配合](#6-与编辑器插件的配合)
+  - [6.1 VS Code](#61-vs-code)
+  - [6.2 Neovim](#62-neovim)
+  - [6.3 其他编辑器](#63-其他编辑器)
+- [7. 常见场景配置示例](#7-常见场景配置示例)
+- [8. 与 `.clang-format` / `.clang-tidy` 的关系](#8-与-clang-format--clang-tidy-的关系)
+- [9. 排查清单（FAQ）](#9-排查清单faq)
+- [10. 本项目当前配置回顾](#10-本项目当前配置回顾)
+
+---
+
+## 1. 概述：clangd 是什么
+
+**clangd** 是 LLVM 项目官方的 C/C++ 语言服务器，遵循 **LSP（Language Server Protocol）** 协议，提供：
+
+- 跳转定义、查找引用、重命名
+- 智能补全（含跨作用域、自动 include）
+- 实时诊断（语法错误 / clang-tidy 静态检查）
+- 代码格式化（调用 clang-format）
+- 内联类型提示（InlayHints）
+- 语义高亮、悬浮信息、调用层级
+
+**重要事实**：
+
+> clangd **是独立的二进制程序**，不属于任何编辑器。  
+> VS Code / Neovim / Emacs / Sublime / CLion 都只是 LSP 客户端，最终启动同一个 `clangd.exe`。  
+> **`.clangd` 配置文件由 clangd 程序自身解析，与编辑器无关。**
+
+---
+
+## 2. 配置层级与优先级
+
+clangd 的配置来自三个层级，**优先级从高到低**：
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ① 编辑器传入的 CLI 参数（如 VS Code 的 clangd.arguments）   │  ← 最高
+├──────────────────────────────────────────────────────────────┤
+│  ② 项目 .clangd 文件（仓库内，进 git）                       │
+├──────────────────────────────────────────────────────────────┤
+│  ③ 用户级 .clangd 文件（~/.config/clangd/config.yaml）       │  ← 最低
+└──────────────────────────────────────────────────────────────┘
+```
+
+**冲突处理规则**：
+
+| 配置项性质 | 冲突时谁生效 | 例子 |
+|---|---|---|
+| 同名标量字段 | CLI > 项目 .clangd > 用户 .clangd | `--compile-commands-dir` 覆盖 `CompilationDatabase` |
+| 列表追加（`Add:` 类） | 合并叠加 | `--clang-tidy-checks=...` 与 `Diagnostics.ClangTidy.Add` 同时生效 |
+| 黑白名单（`Remove:` 类） | 合并叠加 | 多处 `Remove` 取并集 |
+
+**给配置选位置的判断流程**：
+
+```
+是否随项目走？团队需要一致？
+├─ 是 → .clangd 文件（进 git）
+└─ 否 → 编辑器配置（VS Code settings.json / Neovim init.lua）
+```
+
+---
+
+## 3. `.clangd` 文件加载规则
+
+### 3.1 查找路径
+
+clangd 启动后，对每个打开的源文件：
+
+1. 从源文件所在目录开始**向上递归**找 `.clangd` 文件
+2. 找到的多个 `.clangd` 会**叠加生效**（子目录的覆盖父目录的同名字段）
+3. 还会读取用户全局配置：
+   - **Linux/macOS**：`~/.config/clangd/config.yaml`
+   - **Windows**：`%LOCALAPPDATA%\clangd\config.yaml`
+
+### 3.2 启用条件
+
+clangd 必须以 `--enable-config` 启动（**clangd 11+ 默认启用**），否则会无视所有 `.clangd` 文件。
+
+### 3.3 多文档语法
+
+`.clangd` 是 YAML 文件，支持用 `---` 分隔多个文档块，每个块可以有独立的 `If:` 条件：
+
+```yaml
+# 默认配置
+CompileFlags:
+  Add: [-std=c++23]
+
+---
+# 仅对测试目录生效
+If:
+  PathMatch: tests/.*
+Diagnostics:
+  ClangTidy:
+    Remove: [cppcoreguidelines-*]
+```
+
+### 3.4 编辑器响应配置变更
+
+修改 `.clangd` 后，clangd 默认**不会自动重启**。需要：
+
+- **VS Code**：`Ctrl+Shift+P` → `clangd: Restart Language Server`，或在 settings.json 设 `"clangd.onConfigChanged": "restart"` 自动重启
+- **Neovim**：`:LspRestart`
+- **通用**：关闭并重开文件
+
+---
+
+## 4. 完整配置项参考
+
+### 4.1 `CompileFlags`
+
+控制 clangd 看到的编译命令，是最关键的配置块。
+
+```yaml
+CompileFlags:
+  CompilationDatabase: build/my-gcc-relwithdebinfo  # compile_commands.json 所在目录
+  Add:                                              # 追加到所有命令的 flag
+    - -std=c++23
+    - -Wall
+    - -DDEBUG_MODE
+    - -isystem/path/to/private/include
+  Remove:                                           # 从命令中移除的 flag
+    - -Werror
+    - -Werror=*
+    - -fsanitize=*                                  # IDE 不需要 sanitizer 链接
+  Compiler: clang                                   # 强制把 cl.exe / g++ 当作 clang 解析
+```
+
+| 字段 | 类型 | 作用 | 典型用途 |
+|---|---|---|---|
+| `CompilationDatabase` | string | 指定 `compile_commands.json` 目录（相对 .clangd 路径） | 项目用 CMake、build 不在源目录 |
+| `Add` | list[str] | 追加到每条编译命令的 flag | 兜底 `-std=`、补充 include 路径 |
+| `Remove` | list[str] | 从每条命令中移除的 flag（支持 `*` 通配） | 屏蔽 `-Werror`、移除 sanitizer flag |
+| `Compiler` | string | 把命令中的编译器改为指定值 | 强制把 `cl.exe` 当 clang-cl 处理 |
+
+#### 适用场景
+
+- ✅ **总是配 `Add: [-std=cxx]`**：保护新建文件、未在 DB 中的文件
+- ✅ **使用 sanitizer 的项目**：`Remove: [-fsanitize=*]`，IDE 不需要也无法运行 sanitizer
+- ✅ **多目标交叉编译**：用 `If.PathMatch` 配合不同的 `CompilationDatabase`
+
+---
+
+### 4.2 `Completion`
+
+控制代码补全行为。
+
+```yaml
+Completion:
+  AllScopes: Yes              # 全作用域补全
+  HeaderInsertion: IWYU       # 头文件自动插入策略
+```
+
+| 字段 | 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `AllScopes` | `Yes` / `No` | `No` | 即使当前作用域不可见，也建议全局符号；选中后自动补全限定名 |
+| `HeaderInsertion` | `IWYU` / `NeverInsert` | `IWYU` | 是否自动插入 `#include` |
+
+**`AllScopes: Yes` 实战效果**：
+
+```cpp
+int main() {
+    cout << "hi";   // ← clangd 建议 std::cout
+                    //   接受补全后变成 std::cout
+                    //   并自动插入 #include <iostream>
+}
+```
+
+**`HeaderInsertion: IWYU` 实战效果**：
+
+```cpp
+#include <vector>          // <vector> 内部 include 了 <iterator>
+std::vector<int> v;
+for (auto it = std::begin(v); ...) {}   // 用了 std::begin
+//                                      ↑ clangd 提示：建议直接 #include <iterator>
+```
+
+#### 适用场景
+
+- ✅ **强烈推荐开 `AllScopes: Yes`**：极大降低写代码时的认知负担
+- ✅ **现代项目开 `HeaderInsertion: IWYU`**：避免「靠间接传递白嫖头文件」的脆弱代码
+- ❌ **超大项目或代码风格不规范的旧代码库**：`AllScopes: Yes` 可能产生过多噪音
+
+---
+
+### 4.3 `Diagnostics`
+
+控制诊断（红线 / 黄线 / quickfix）。
+
+```yaml
+Diagnostics:
+  Suppress:                   # 屏蔽特定 clang 编译器诊断
+    - unused-parameter
+    - shadow
+  MissingIncludes: Strict     # 报告缺失 include
+  UnusedIncludes: Strict      # 报告多余 include
+  UnusedIncludesAllowAngled: Yes  # 角括号 include 不报多余（用于第三方库）
+  ClangTidy:
+    Add:
+      - modernize-*
+      - performance-*
+    Remove:
+      - modernize-use-trailing-return-type
+    CheckOptions:
+      readability-identifier-naming.VariableCase: camelBack
+```
+
+| 字段 | 取值 | 说明 |
+|---|---|---|
+| `Suppress` | list[str] / `"*"` | 屏蔽指定 clang 警告 ID（不带 `-W` 前缀），`"*"` 全部 |
+| `MissingIncludes` | `Strict` / `None` | 是否报告「用了某符号但没直接 include」 |
+| `UnusedIncludes` | `Strict` / `None` | 是否报告「include 了但没用」 |
+| `UnusedIncludesAllowAngled` | `Yes` / `No` | 仅检查 `"..."` 形式的 include，跳过 `<...>`（第三方库友好） |
+| `ClangTidy.Add` | list[str] | 启用的 clang-tidy 检查（支持 `*` 通配组） |
+| `ClangTidy.Remove` | list[str] | 关闭的具体规则 |
+| `ClangTidy.CheckOptions` | map | 给具体规则传选项（如命名风格、阈值） |
+
+#### `Suppress` 使用警告
+
+> ⚠️ **谨慎使用 `Suppress`** —— 它**只对 IDE 屏蔽，不影响实际编译**。  
+> 如果 CI 用 `-Werror`，IDE 看不到的 warning 会让构建失败，本地无法复现。
+
+合理场景：
+
+```yaml
+# 仅对第三方库屏蔽，不影响项目代码
+If:
+  PathMatch: .*/vcpkg_installed/.*
+Diagnostics:
+  Suppress: "*"
+```
+
+#### clang-tidy 检查规则速查
+
+| 组 | 用途 |
+|---|---|
+| `bugprone-*` | 易出错模式（建议**全开**） |
+| `cert-*` | CERT 安全编码规范 |
+| `clang-analyzer-*` | clang 静态分析器（默认就开） |
+| `concurrency-*` | 并发相关问题 |
+| `cppcoreguidelines-*` | C++ Core Guidelines（含部分严苛规则） |
+| `google-*` | Google C++ Style |
+| `hicpp-*` | High Integrity C++ |
+| `llvm-*` | LLVM 项目编码规范 |
+| `misc-*` | 杂项检查 |
+| `modernize-*` | 现代 C++ 改写建议（建议**全开**） |
+| `performance-*` | 性能优化建议（建议**全开**） |
+| `portability-*` | 可移植性问题 |
+| `readability-*` | 可读性改进（建议**全开**） |
+
+**通用配方**（本项目就是这套）：
+
+```yaml
+ClangTidy:
+  Add: [modernize-*, performance-*, bugprone-*, readability-*, cppcoreguidelines-*]
+  Remove:
+    - modernize-use-trailing-return-type
+    - readability-identifier-length
+    - readability-magic-numbers
+    - cppcoreguidelines-avoid-magic-numbers
+    - cppcoreguidelines-pro-bounds-pointer-arithmetic
+    - cppcoreguidelines-pro-bounds-array-to-pointer-decay
+```
+
+---
+
+### 4.4 `Index`
+
+控制后台索引（驱动跳转、查找引用、全局补全）。
+
+```yaml
+Index:
+  Background: Build           # 后台索引模式
+  StandardLibrary: Yes        # 索引标准库（默认 Yes）
+  External:                   # 引入外部预建索引
+    File: /path/to/external.idx
+    Server: tcp://host:port
+    MountPoint: /repo/path
+```
+
+| 字段 | 取值 | 默认 | 说明 |
+|---|---|---|---|
+| `Background` | `Build` / `Skip` | `Build` | 后台是否索引该范围的文件 |
+| `StandardLibrary` | `Yes` / `No` | `Yes` | 是否索引标准库（关闭可省内存，但失去 STL 跳转） |
+| `External` | object | - | 加载预生成的索引文件或连接索引服务器 |
+
+#### 适用场景
+
+```yaml
+# 跳过第三方代码索引（节省 CPU/磁盘）
+---
+If:
+  PathMatch: third_party/.*
+Index:
+  Background: Skip
+```
+
+```yaml
+# 大型 monorepo 用预建索引
+Index:
+  External:
+    File: /shared/index/myproject.idx
+```
+
+---
+
+### 4.5 `InlayHints`
+
+控制编辑器内联提示。
+
+```yaml
+InlayHints:
+  Enabled: Yes                # 总开关
+  ParameterNames: Yes         # 形参名提示
+  DeducedTypes: Yes           # auto 推导类型
+  Designators: Yes            # 聚合初始化成员名
+  BlockEnd: Yes               # 长块结尾标注
+  DefaultArguments: Yes       # 默认参数值
+  TypeNameLimit: 32           # 类型名长度上限（超过则省略）
+```
+
+| 字段 | 默认 | 效果示例 |
+|---|---|---|
+| `Enabled` | `Yes` | 总开关，关掉则全部不显示 |
+| `ParameterNames` | `Yes` | `foo(/*x:*/ 1, /*y:*/ 2)` |
+| `DeducedTypes` | `Yes` | `auto x = getValue();` 旁显示 `/* int */` |
+| `Designators` | `Yes` | `Point{/*.x=*/ 1, /*.y=*/ 2}` |
+| `BlockEnd` | `No` | 长函数 `}` 后显示 `// foo` |
+| `DefaultArguments` | `No` | `foo(1)` 显示 `foo(1, /*y=*/ 10)` |
+| `TypeNameLimit` | 32 | `DeducedTypes` 类型名超长时截断 |
+
+#### 编辑器侧渲染
+
+| 编辑器 | 是否需要额外开启 |
+|---|---|
+| VS Code | ❌ 自动渲染 |
+| Neovim 0.10+ | ✅ 需 `vim.lsp.inlay_hint.enable(true)` |
+| Helix | ❌ 自动渲染 |
+| Emacs eglot | ✅ 需 `M-x eglot-inlay-hints-mode` |
+
+#### 适用场景
+
+- ✅ **开发期开全部**：信息密度高，理解代码更快
+- ⚠️ **结对编程 / 演讲分享**：可能让屏幕显得拥挤，按需关闭 `DefaultArguments` 和 `Designators`
+
+---
+
+### 4.6 `Hover`
+
+控制鼠标悬停提示。
+
+```yaml
+Hover:
+  ShowAKA: Yes                # 显示类型别名的真实类型（Also Known As）
+```
+
+| 字段 | 默认 | 效果 |
+|---|---|---|
+| `ShowAKA` | `No` | 悬停 `using MyInt = int; MyInt x;` 时显示 `MyInt (aka int)` |
+
+**适用**：项目重度使用 type alias 时建议开。
+
+---
+
+### 4.7 `SemanticTokens`
+
+控制语义高亮。
+
+```yaml
+SemanticTokens:
+  DisabledKinds: [Operator]
+  DisabledModifiers: [Deprecated]
+```
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `DisabledKinds` | list[str] | 不发送语义 token 的种类（编辑器退化为正则高亮该种类） |
+| `DisabledModifiers` | list[str] | 不发送的修饰符 |
+
+**常见取值**：`Type` `Class` `Property` `Variable` `Function` `Method` `Macro` `Concept` `Operator` `Bracket` `Number` `Comment` `Keyword`
+
+**绝大多数情况下不需要配置**，只有调主题颜色与 token 类型冲突时才考虑关闭某类。
+
+---
+
+### 4.8 `Style`
+
+控制部分代码风格相关行为（不是格式化，格式化看 `.clang-format`）。
+
+```yaml
+Style:
+  FullyQualifiedNamespaces: Yes
+```
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `FullyQualifiedNamespaces` | `No` | 自动补全的命名空间是否用完整路径（`std::vector` 而非 `vector`） |
+
+⚠️ **注意**：`.clangd` **没有 `FallbackStyle` 字段**。设置默认格式化风格只能用 CLI 参数 `--fallback-style=Google`，或更推荐 —— 在仓库根放 `.clang-format` 文件。
+
+---
+
+### 4.9 `If` —— 条件配置
+
+让任意配置块仅对特定文件生效。
+
+```yaml
+If:
+  PathMatch: tests/.*\.cpp$       # 路径正则
+  PathExclude: build/.*           # 排除路径
+Diagnostics:
+  ClangTidy:
+    Remove: [cppcoreguidelines-*]
+```
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `PathMatch` | string / list | 仅对匹配的路径应用本配置块（正则） |
+| `PathExclude` | string / list | 排除匹配的路径 |
+
+**实战示例**：
+
+```yaml
+# 默认严格规则
+Diagnostics:
+  UnusedIncludes: Strict
+
+---
+# 测试代码放宽（gtest 大量使用 macro，UnusedIncludes 容易误报）
+If:
+  PathMatch: .*/tests/.*
+Diagnostics:
+  UnusedIncludes: None
+
+---
+# 第三方库完全不查
+If:
+  PathMatch: .*/(vcpkg_installed|third_party|_deps)/.*
+Diagnostics:
+  Suppress: "*"
+Index:
+  Background: Skip
+```
+
+---
+
+## 5. clangd CLI 参数（编辑器侧）
+
+不能写在 `.clangd` 里、必须通过编辑器传给 clangd 进程的常用参数：
+
+| CLI 参数 | 作用 | 推荐值 |
+|---|---|---|
+| `--background-index` | 后台索引（默认开） | 显式声明 |
+| `--clang-tidy` | 启用 clang-tidy（默认开） | 显式声明 |
+| `--enable-config` | 启用 .clangd 文件（默认开） | 显式声明 |
+| `--query-driver=<glob>` | 允许 clangd 查询非 clang 编译器 | **MinGW/交叉编译必配** |
+| `--header-insertion-decorators` | 补全列表用圆点标记「未引入头文件」 | 推荐 |
+| `--completion-style=detailed` | 重载函数显示每个签名 | 推荐 |
+| `--function-arg-placeholders=true` | 补全函数生成参数占位符 | 推荐 |
+| `--fallback-style=Google` | 无 .clang-format 时的格式化风格 | 见下 |
+| `--pch-storage=memory` | PCH 放内存加快索引 | 内存够时推荐 |
+| `--ranking-model=decision_forest` | 补全排序用决策树模型 | 推荐 |
+| `--log=verbose` | 详细日志（调试用） | 定型后改 `info` |
+| `-j=N` | 索引并发线程数 | CPU 核数 - 2 |
+
+**关于 `--query-driver`**：
+
+- 路径**必须用绝对路径**，相对 glob（`**/g++*`）在新版 clangd 可能不生效
+- MinGW 项目示例：`--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*`
+- 没配会导致 `<bit>` `<cstdint>` 等 STL 头找不到，或加载错版本（误用 MSVC STL）
+
+**关于 `--fallback-style`**：
+
+- `.clangd` **不支持**对应字段
+- 项目级风格强烈建议**用 `.clang-format` 文件**（生成方法：`clang-format -style=Google -dump-config > .clang-format`）
+- 有 `.clang-format` 后 `--fallback-style` 永远不会触发
+
+---
+
+## 6. 与编辑器插件的配合
+
+### 6.1 VS Code
+
+**插件**：`llvm-vs-code-extensions.vscode-clangd`
+
+**关键设置**（`.vscode/settings.json` 或用户 settings）：
+
+```jsonc
+{
+  // 检测与 Microsoft C/C++ 扩展冲突
+  "clangd.detectExtensionConflicts": true,
+
+  // .clangd 改动后自动重启
+  "clangd.onConfigChanged": "restart",
+
+  // CLI 参数（不能写进 .clangd 的项目）
+  "clangd.arguments": [
+    "--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*",
+    "--completion-parse=auto",
+    "--completion-style=detailed",
+    "--fallback-style=Google",
+    "--function-arg-placeholders=true",
+    "--header-insertion-decorators",
+    "--log=verbose",
+    "--pch-storage=memory",
+    "--pretty",
+    "--ranking-model=decision_forest",
+    "-j=12"
+  ],
+
+  // 仅在没有 compile_commands.json 时使用的 flags
+  "clangd.fallbackFlags": ["-std=c++23"]
+}
+```
+
+**禁用 Microsoft C/C++ 扩展的 IntelliSense**（避免冲突）：
+
+```jsonc
+{
+  "C_Cpp.intelliSenseEngine": "disabled"
+}
+```
+
+---
+
+### 6.2 Neovim
+
+**插件**：`nvim-lspconfig`（社区主流）或 Neovim 0.11+ 内置 `vim.lsp.config`
+
+**`nvim-lspconfig` 写法**：
+
+```lua
+require('lspconfig').clangd.setup({
+  cmd = {
+    'clangd',
+    '--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*',
+    '--completion-parse=auto',
+    '--completion-style=detailed',
+    '--fallback-style=Google',
+    '--function-arg-placeholders=true',
+    '--header-insertion-decorators',
+    '--log=verbose',
+    '--pch-storage=memory',
+    '--pretty',
+    '--ranking-model=decision_forest',
+    '-j=12',
+  },
+  init_options = {
+    fallbackFlags = { '-std=c++23' },
+  },
+  on_attach = function(client, bufnr)
+    vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })  -- 启用 InlayHints 渲染
+  end,
+})
+```
+
+**Neovim 0.11+ 原生写法**：
+
+```lua
+vim.lsp.config('clangd', {
+  cmd = { 'clangd', '--query-driver=...', ... },
+  root_markers = { '.clangd', 'compile_commands.json', '.git' },
+  filetypes = { 'c', 'cpp', 'objc', 'objcpp' },
+})
+vim.lsp.enable('clangd')
+```
+
+---
+
+### 6.3 其他编辑器
+
+| 编辑器 | 插件 | CLI 参数配置位置 |
+|---|---|---|
+| Emacs (eglot) | 内置 | `eglot-server-programs` 中的 cmd |
+| Emacs (lsp-mode) | `lsp-mode` | `lsp-clients-clangd-args` |
+| Sublime Text | LSP-clangd | Package settings 的 `command` |
+| Helix | 内置 | `languages.toml` 的 `language-server.clangd` |
+| CLion | 内置（fork） | Settings → Languages & Frameworks → C/C++ → Clangd |
+
+**通用原则**：所有编辑器的「clangd 参数配置」最终都对应 clangd 进程的 CLI 参数，写法不同但含义相同。
+
+---
+
+## 7. 常见场景配置示例
+
+### 7.1 Windows + MinGW（本项目场景）
+
+```yaml
+CompileFlags:
+  CompilationDatabase: build/my-gcc-relwithdebinfo
+  Add: [-std=c++23, -Wall, -Wextra, -Wpedantic]
+```
+
+**额外**：VS Code `clangd.arguments` 必须配 `--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*`。
+
+---
+
+### 7.2 多 Preset 切换
+
+`.clangd` 硬编码一个 preset 不灵活。三种解决方案：
+
+#### 方案 A：把 .clangd 加进 .gitignore，每人本地维护
+
+```bash
+# .gitignore
+.clangd
+```
+
+每次切 preset 改本地 `.clangd` 一行。
+
+#### 方案 B：CMake 自动复制 compile_commands.json 到根目录
+
+```cmake
+# CMakeLists.txt
+add_custom_target(copy_compile_commands ALL
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json)
+```
+
+`.clangd` 删掉 `CompilationDatabase` 字段，clangd 自动从根目录加载。
+
+#### 方案 C：用环境变量（少见）
+
+CLI 参数 `--compile-commands-dir="$PRESET_BUILD_DIR"`，shell 启动 clangd 前 export 变量。
+
+---
+
+### 7.3 屏蔽第三方库诊断
+
+```yaml
+---
+If:
+  PathMatch: .*/(vcpkg_installed|third_party|_deps|/usr/include)/.*
+Diagnostics:
+  Suppress: "*"
+  ClangTidy:
+    Remove: ["*"]
+Index:
+  Background: Skip
+```
+
+---
+
+### 7.4 测试代码放宽规则
+
+```yaml
+---
+If:
+  PathMatch: .*/tests/.*
+Diagnostics:
+  UnusedIncludes: None         # gtest 用大量 macro，容易误报
+  ClangTidy:
+    Remove:
+      - cppcoreguidelines-avoid-non-const-global-variables  # gtest fixture
+      - readability-function-cognitive-complexity            # 测试逻辑常常很长
+```
+
+---
+
+### 7.5 强制特定命名规范
+
+```yaml
+Diagnostics:
+  ClangTidy:
+    Add: [readability-identifier-naming]
+    CheckOptions:
+      readability-identifier-naming.ClassCase: CamelCase
+      readability-identifier-naming.FunctionCase: camelBack
+      readability-identifier-naming.VariableCase: lower_case
+      readability-identifier-naming.ConstantCase: UPPER_CASE
+      readability-identifier-naming.PrivateMemberSuffix: _
+```
+
+---
+
+### 7.6 性能调优（巨型项目）
+
+```yaml
+Index:
+  Background: Build
+  StandardLibrary: No          # 不索引 STL（损失 STL 跳转，节省内存）
+
+---
+If:
+  PathMatch: .*/(generated|proto|grpc)/.*
+Index:
+  Background: Skip             # 跳过自动生成的代码
+```
+
+CLI 配合：`--pch-storage=disk`（内存吃紧时）、`-j=4`（限制并发）。
+
+---
+
+## 8. 与 `.clang-format` / `.clang-tidy` 的关系
+
+`.clangd` 是「**语言服务行为**」配置，clang 工具链中其他配置文件各有职责：
+
+| 文件 | 作用 | 由谁读 | 是否进 git |
+|---|---|---|---|
+| `.clangd` | clangd 行为配置 | clangd | ✅ 推荐 |
+| `.clang-format` | 代码格式化规则 | clang-format / clangd | ✅ 必须 |
+| `.clang-tidy` | clang-tidy 规则 | clang-tidy / clangd | ✅ 推荐 |
+| `compile_commands.json` | 编译命令数据库 | clangd / clang-tidy | ❌ 自动生成 |
+| `.clangd-tidy` | （不存在） | - | - |
+
+### 8.1 `.clang-format` —— 代码格式化
+
+```yaml
+# .clang-format
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Inline
+```
+
+**生成方法**：
+
+```bash
+clang-format -style=Google -dump-config > .clang-format
+```
+
+**与 `.clangd` 的关系**：clangd 调用 clang-format 时自动读取 `.clang-format`。`.clangd` 没有任何与代码格式化相关的字段。
+
+---
+
+### 8.2 `.clang-tidy` —— 独立的 clang-tidy 配置
+
+```yaml
+# .clang-tidy
+Checks: 'modernize-*,bugprone-*,-modernize-use-trailing-return-type'
+WarningsAsErrors: ''
+HeaderFilterRegex: '^(?!.*third_party).*$'
+CheckOptions:
+  - key: readability-identifier-length.MinimumVariableNameLength
+    value: 2
+```
+
+**与 `.clangd.Diagnostics.ClangTidy` 的关系**：
+
+- 命令行 `clang-tidy` 工具读 `.clang-tidy`
+- clangd 内置的 clang-tidy **同时读 `.clang-tidy` 和 `.clangd` 中的 `Diagnostics.ClangTidy`**
+- 两者**合并叠加**
+
+**推荐策略**：
+
+- **小项目**：只在 `.clangd` 里配，避免冗余
+- **大项目（CI 也跑 clang-tidy）**：把 checks 写在 `.clang-tidy`（命令行和 IDE 共用），`.clangd` 只做 IDE 特定的微调
+
+---
+
+## 9. 排查清单（FAQ）
+
+### Q1：clangd 找不到第三方库头文件（如 `<gtest/gtest.h>`）
+
+**检查顺序**：
+
+1. `compile_commands.json` 是否存在且包含该文件？
+   ```bash
+   grep "your_file.cpp" build/<preset>/compile_commands.json
+   ```
+2. `.clangd` 的 `CompilationDatabase` 是否指向正确的 build 目录？
+3. VS Code `clangd.arguments` 中 `--compile-commands-dir` 是否覆盖了 `.clangd`？
+4. compile_commands.json 中的 `-I` / `-isystem` 路径是否实际存在？
+5. 重启 clangd（`Ctrl+Shift+P` → `clangd: Restart Language Server`）
+6. 清理 clangd 缓存：删除 `%LOCALAPPDATA%\clangd\index\` 后重启编辑器
+
+---
+
+### Q2：clangd 找不到标准库头文件（如 `<bit>` `<cstdint>`）
+
+通常是 **`--query-driver` 没配或没生效**。
+
+```jsonc
+"clangd.arguments": [
+  "--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*"
+]
+```
+
+验证：VS Code → 输出面板 → 选 `clangd`，看启动日志：
+
+```
+I[xx:xx:xx.xxx] Compiler driver F:\scoop\apps\msys2\current\ucrt64\bin\g++.exe is allowed by query-driver
+```
+
+如果出现 `is not allowed by query-driver`，路径未匹配。
+
+---
+
+### Q3：clang-tidy 检查没生效
+
+1. CLI 是否带 `--clang-tidy`（默认开，但有些发行版关了）
+2. `.clangd` 的 `Diagnostics.ClangTidy.Add` 是否写对（注意 `*` 是组通配，不是正则）
+3. 项目里是否有 `.clang-tidy` 文件覆盖了 `.clangd` 的设置
+4. clangd 输出日志中是否有 `clang-tidy: enabled checks: ...`
+
+---
+
+### Q4：InlayHints 不显示
+
+- **VS Code**：检查 settings.json 中 `editor.inlayHints.enabled` 是否为 `on`
+- **Neovim**：缺少 `vim.lsp.inlay_hint.enable(true)` 调用
+- 确认 `.clangd` 中 `InlayHints.Enabled: Yes`
+
+---
+
+### Q5：`.clangd` 修改后没生效
+
+1. 重启 clangd（`Ctrl+Shift+P` → `clangd: Restart Language Server`）
+2. 配置 `"clangd.onConfigChanged": "restart"` 让它自动重启
+3. YAML 缩进/语法是否正确（VS Code 中 `.clangd` 文件不会语法高亮，建议用 yamllint 检查）
+
+---
+
+### Q6：补全很慢 / clangd 占用大量 CPU
+
+1. 缩小索引范围：`If: { PathMatch: third_party/.* } Index: { Background: Skip }`
+2. 限制并发：CLI 加 `-j=4`
+3. PCH 存内存：`--pch-storage=memory`（前提是内存够）
+4. 关闭 STL 索引：`Index: { StandardLibrary: No }`（损失 STL 跳转）
+
+---
+
+### Q7：VS Code 中红线很多但实际能编译
+
+1. `compile_commands.json` 中的 flag 与实际编译时不一致
+2. clangd 平台与编译器平台不匹配（如 MSVC clangd 解析 MinGW 项目，未配 `--query-driver`）
+3. `-D` 宏定义缺失，看实际编译时的 -D 是否在 compile_commands.json 中
+
+---
+
+## 10. 本项目当前配置回顾
+
+```yaml
+CompileFlags:
+  CompilationDatabase: build/my-gcc-relwithdebinfo
+  Add: [-std=c++23, -Wall, -Wextra, -Wpedantic]
+
+Completion:
+  AllScopes: Yes              # 全局补全 + 自动补 std::
+  HeaderInsertion: IWYU       # 自动 #include
+
+Diagnostics:
+  MissingIncludes: Strict     # 缺 include 警告
+  UnusedIncludes: Strict      # 多余 include 警告
+  ClangTidy:
+    Add: [modernize-*, performance-*, bugprone-*, readability-*, cppcoreguidelines-*]
+    Remove: [
+      modernize-use-trailing-return-type,
+      readability-identifier-length,
+      readability-magic-numbers,
+      cppcoreguidelines-avoid-magic-numbers,
+      cppcoreguidelines-pro-bounds-pointer-arithmetic,
+      cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+    ]
+
+Index:
+  Background: Build           # 后台索引
+
+InlayHints:
+  Enabled: Yes
+  ParameterNames: Yes
+  DeducedTypes: Yes
+  Designators: Yes
+  BlockEnd: Yes
+  DefaultArguments: Yes
+```
+
+**配套 VS Code `clangd.arguments`**：
+
+```jsonc
+[
+  "--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/*",
+  "--completion-parse=auto",
+  "--completion-style=detailed",
+  "--fallback-style=Google",
+  "--function-arg-placeholders=true",
+  "--header-insertion-decorators",
+  "--log=verbose",
+  "--pch-storage=memory",
+  "--pretty",
+  "--ranking-model=decision_forest",
+  "-j=12"
+]
+```
+
+**当前未启用但可考虑的扩展**：
+
+- 在仓库根放 `.clang-format` 取代 `--fallback-style`
+- 用 `If.PathMatch` 对 `tests/` 放宽 `UnusedIncludes`
+- 用 `If.PathMatch` 对 `vcpkg_installed/` 全局 Suppress
+- 切换 preset 频繁时改用 CMake `add_custom_target` 自动复制 compile_commands.json
+
+---
+
+## 参考资料
+
+- clangd 官方配置文档：<https://clangd.llvm.org/config>
+- clang-tidy 检查列表：<https://clang.llvm.org/extra/clang-tidy/checks/list.html>
+- clang-format 选项：<https://clang.llvm.org/docs/ClangFormatStyleOptions.html>
+- LSP 协议规范：<https://microsoft.github.io/language-server-protocol/>

--- a/docs/clangd-toolchain-overview.md
+++ b/docs/clangd-toolchain-overview.md
@@ -1,0 +1,454 @@
+# clangd 工具链整体使用框架
+
+> 本文档描述 clangd 如何串联 `.clangd`、`.clang-format`、`.clang-tidy`、`compile_commands.json` 这一整套配置文件，作为 C++ LSP 工具链的"鸟瞰图"。
+>
+> 单文件细节请看：
+> - [`clangd-config-guide.md`](./clangd-config-guide.md) —— `.clangd` 完整配置参考
+> - [`clang-format-config-guide.md`](./clang-format-config-guide.md) —— `.clang-format` 完整配置参考
+> - [`clang-tidy-config-guide.md`](./clang-tidy-config-guide.md) —— `.clang-tidy` 完整配置参考
+
+---
+
+## 目录
+
+1. [整体架构图](#1-整体架构图)
+2. [四类配置文件的分工](#2-四类配置文件的分工)
+3. [clangd 启动流程](#3-clangd-启动流程)
+4. [典型 LSP 请求的内部链路](#4-典型-lsp-请求的内部链路)
+5. [优先级与覆盖关系](#5-优先级与覆盖关系)
+6. [推荐的项目布局](#6-推荐的项目布局)
+7. [本项目实际配置全貌](#7-本项目实际配置全貌)
+8. [新建项目的最小可用模板](#8-新建项目的最小可用模板)
+9. [常见配置组合速查](#9-常见配置组合速查)
+10. [排查问题的顺序](#10-排查问题的顺序)
+
+---
+
+## 1. 整体架构图
+
+```
+                    ┌──────────────────────────────────┐
+                    │  编辑器（VS Code / Neovim / ...）│
+                    │   - clangd 插件 / nvim-lspconfig │
+                    │   - clangd.arguments（CLI 参数） │
+                    └─────────────┬────────────────────┘
+                                  │ LSP（JSON-RPC over stdio）
+                                  ▼
+                    ┌──────────────────────────────────┐
+                    │             clangd               │
+                    │  （C++ Language Server）         │
+                    │                                  │
+                    │  读取：                          │
+                    │   - CLI 参数（最高优先级）       │
+                    │   - .clangd 文件                 │
+                    │   - compile_commands.json        │
+                    └─┬────────┬───────────┬───────────┘
+                      │        │           │
+            ┌─────────┘        │           └──────────┐
+            ▼                  ▼                      ▼
+   ┌──────────────────┐  ┌──────────────┐    ┌─────────────────┐
+   │   编译诊断       │  │ clang-tidy   │    │  clang-format   │
+   │ (libclang AST)   │  │ (内嵌调用)    │    │  (内嵌调用)     │
+   │                  │  │              │    │                 │
+   │ 用：             │  │ 读取：       │    │ 读取：          │
+   │  compile_        │  │  .clang-tidy │    │  .clang-format  │
+   │  commands.json   │  │              │    │                 │
+   └──────────────────┘  └──────────────┘    └─────────────────┘
+```
+
+四个数据来源、三个执行引擎、一个对外接口（LSP）。
+
+---
+
+## 2. 四类配置文件的分工
+
+| 文件 | 谁用 | 关心的事 | 何时被读 |
+|---|---|---|---|
+| **`.clangd`** | clangd 自身 | LSP 行为：CompileFlags、Completion、Diagnostics 总开关、InlayHints、Index、Hover... | clangd 启动时（需 `--enable-config`，默认开） |
+| **`compile_commands.json`** | clangd 的编译前端 | 每个 .cpp 用什么 flag 编译（标准、include 路径、宏） | 打开文件时 |
+| **`.clang-format`** | clang-format（被 clangd 调用） | 代码格式化规则 | 触发 `formatting` 请求时 |
+| **`.clang-tidy`** | clang-tidy（被 clangd 内嵌调用） | 静态检查规则、命名规范、性能/安全建议 | 文件打开/编辑时 |
+
+**记住一句话**：
+- `compile_commands.json` 决定 clangd「**懂不懂**」你的代码（找头文件、解析符号）
+- `.clangd` 决定 clangd「**做什么**」（要不要跑 tidy、要不要插头、提示样式）
+- `.clang-tidy` 决定 tidy「**查什么**」（具体哪些规则）
+- `.clang-format` 决定格式化「**怎么排**」
+
+---
+
+## 3. clangd 启动流程
+
+时间顺序：
+
+```
+1. 编辑器启动 → 启动 clangd 子进程，传入 CLI 参数
+                  （--compile-commands-dir, --query-driver, --fallback-style ...）
+
+2. clangd 接收 LSP initialize 请求
+   - 拿到 workspace 根目录
+   - 加载 ~/.config/clangd/config.yaml（用户全局）
+   - 加载 <workspace>/.clangd（项目级）
+   - 合并：CLI 参数 > .clangd > 全局 config.yaml > 内置默认
+
+3. 用户打开一个 .cpp 文件
+   - clangd 沿着文件目录向上找 compile_commands.json
+     · 优先用 CLI --compile-commands-dir 指定的位置
+     · 否则用 .clangd 中 CompileFlags.CompilationDatabase 指定
+     · 否则递归向上找
+   - 拿到该文件的编译命令（含 -std、-I、-D、-isystem 等）
+   - 启动后台索引（如果 Index.Background: Build）
+
+4. 解析 + 诊断
+   - 用 libclang 解析为 AST
+   - 跑编译器警告
+   - 跑 clang-tidy（如果 .clangd 没禁用）
+     · tidy 沿着文件目录向上找 .clang-tidy
+     · 合并 .clangd 中的 Diagnostics.ClangTidy 配置
+   - 把所有诊断包装成 LSP diagnostics 推给编辑器
+```
+
+---
+
+## 4. 典型 LSP 请求的内部链路
+
+### 4.1 打开文件 / 实时编辑
+
+```
+编辑器: textDocument/didOpen / didChange
+   │
+   ▼
+clangd
+   ├─ 查 compile_commands.json → 拿到编译参数
+   ├─ libclang 解析 → AST
+   ├─ 编译警告（-Wall -Wextra -Wpedantic 由 .clangd 的 CompileFlags.Add 追加）
+   └─ clang-tidy 内嵌运行 → 读 .clang-tidy → 合并 .clangd 的 ClangTidy 配置
+                                                      │
+                                                      ▼
+   ◄── 所有诊断 → textDocument/publishDiagnostics ──┘
+```
+
+### 4.2 代码补全
+
+```
+编辑器: textDocument/completion
+   │
+   ▼
+clangd
+   ├─ 查当前作用域可见符号
+   ├─ 如果 .clangd 的 Completion.AllScopes: Yes → 全局符号也建议
+   ├─ 如果 .clangd 的 Completion.HeaderInsertion: IWYU → 自动追加 #include
+   └─ 返回补全候选列表
+```
+
+### 4.3 格式化
+
+```
+编辑器: textDocument/formatting
+   │
+   ▼
+clangd
+   ├─ 找 .clang-format（向上递归）
+   ├─ 找不到 → 用 CLI --fallback-style 指定的内置风格
+   └─ 调用内嵌 clang-format → 返回 TextEdit 列表
+```
+
+### 4.4 跳转定义
+
+```
+编辑器: textDocument/definition
+   │
+   ▼
+clangd
+   ├─ 查后台索引（如果 Index.Background: Build）
+   ├─ 没索引就实时 parse 项目
+   └─ 返回 LocationLink
+```
+
+### 4.5 InlayHints
+
+```
+编辑器: textDocument/inlayHint
+   │
+   ▼
+clangd
+   ├─ 检查 .clangd 的 InlayHints.Enabled
+   ├─ 按子开关（ParameterNames / DeducedTypes / ...）生成提示
+   └─ 返回 InlayHint 列表
+```
+
+---
+
+## 5. 优先级与覆盖关系
+
+### 5.1 编译参数（CompileFlags）
+
+```
+[最高] CLI 参数（如 VS Code clangd.arguments 中的 --query-driver）
+   ▲
+   │ 覆盖
+.clangd 中的 CompileFlags.Add / CompileFlags.Remove
+   ▲
+   │ 应用到
+compile_commands.json 里的原始命令
+```
+
+### 5.2 tidy 规则
+
+```
+[最高] CLI 的 --checks=... （手动跑 clang-tidy 时）
+   ▲
+   │ 覆盖
+.clang-tidy 中的 Checks
+   ▲
+   │ 覆盖
+.clangd 中的 Diagnostics.ClangTidy
+```
+
+注意：**只要项目有 `.clang-tidy`，`.clangd` 里的 ClangTidy 配置基本就被忽略了**。所以二选一，要么集中在 `.clang-tidy`（推荐），要么集中在 `.clangd`。
+
+### 5.3 格式化风格
+
+```
+[最高] CLI 的 --style=... （手动跑 clang-format 时）
+   ▲
+   │ 覆盖
+.clang-format（最近的，向上递归）
+   ▲
+   │ 覆盖（找不到 .clang-format 时）
+clangd CLI 的 --fallback-style
+   ▲
+   │ 覆盖
+clang-format 内置默认（LLVM）
+```
+
+### 5.4 配置文件就近优先
+
+`.clangd`、`.clang-format`、`.clang-tidy` 都遵循**就近优先**原则：
+
+```
+project/
+├── .clang-tidy                  # 主配置
+├── tests/
+│   └── .clang-tidy              # 测试目录覆盖（默认替换；继承需 InheritParentConfig: true）
+└── third_party/
+    └── .clang-tidy              # 三方目录关掉所有
+```
+
+`.clangd` 比较特殊，它支持 `If` 条件块在**同一个文件内**按路径分流，所以一般只在项目根放一份。
+
+---
+
+## 6. 推荐的项目布局
+
+```
+ModernCpp/
+├── CMakeLists.txt
+├── CMakePresets.json
+├── CMakeUserPresets.json
+├── compile_commands.json        # （可选）软链接到当前活跃 build
+│
+├── .clangd                      # clangd LSP 配置（已有）
+├── .clang-format                # 代码格式化规则（已有）
+├── .clang-tidy                  # 静态检查规则（已有）
+│
+├── .vscode/
+│   └── settings.json            # 含 clangd.arguments
+│
+├── docs/
+│   ├── clangd-toolchain-overview.md   # 本文（鸟瞰）
+│   ├── clangd-config-guide.md         # .clangd 详细
+│   ├── clang-format-config-guide.md   # .clang-format 详细
+│   └── clang-tidy-config-guide.md     # .clang-tidy 详细
+│
+├── modules/
+│   └── 01_basics/
+│       ├── CMakeLists.txt
+│       ├── demos/
+│       └── tests/
+│           └── (可选) .clang-tidy   # 测试目录放宽规则
+│
+├── third_party/
+│   └── (可选) .clang-tidy           # Checks: '-*'
+│
+└── build/
+    └── my-gcc-relwithdebinfo/
+        └── compile_commands.json    # CMake 生成
+```
+
+---
+
+## 7. 本项目实际配置全貌
+
+### 7.1 三个配置文件的分工
+
+| 文件 | 主要内容 |
+|---|---|
+| **`.clangd`** | `CompilationDatabase: build/my-gcc-relwithdebinfo`、`-std=c++23 -Wall -Wextra -Wpedantic`、`AllScopes/IWYU`、`MissingIncludes/UnusedIncludes: Strict`、ClangTidy 启用组、Index.Background: Build、InlayHints 全开 |
+| **`.clang-format`** | `BasedOnStyle: Google` + 4 空格缩进 + 100 列宽 + `PointerAlignment: Left` + `IncludeBlocks: Regroup` |
+| **`.clang-tidy`** | 主流 6 组 check（bugprone/cert/cppcoreguidelines/modernize/performance/readability）+ Google 命名风格 + 函数大小阈值 |
+
+### 7.2 编辑器侧（VS Code 推荐配置）
+
+```jsonc
+{
+  // 保存时格式化（调用 clang-format 经 clangd）
+  "editor.formatOnSave": true,
+  "[cpp]": { "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd" },
+  "[c]":   { "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd" },
+
+  // clangd 启动参数
+  "clangd.arguments": [
+    // MinGW 必需：让 clangd 用 g++ 推断标准头/宏
+    "--query-driver=F:/scoop/apps/msys2/current/ucrt64/bin/g++.exe",
+
+    // 找不到 .clang-format 时的兜底（项目里有 .clang-format 时可注释掉）
+    // "--fallback-style=Google",
+
+    // 以下都可由 .clangd 配置实现，CLI 中无需重复：
+    // --background-index           （默认开）
+    // --clang-tidy                 （默认开）
+    // --enable-config              （默认开）
+    // --all-scopes-completion      （已在 .clangd Completion.AllScopes）
+    // --header-insertion=iwyu      （已在 .clangd Completion.HeaderInsertion）
+    // --compile-commands-dir=...   （已在 .clangd CompileFlags.CompilationDatabase）
+  ]
+}
+```
+
+### 7.3 切换 build preset 时
+
+只需修改 `.clangd` 中一行：
+
+```yaml
+CompileFlags:
+  CompilationDatabase: build/my-gcc-debug    # 从 relwithdebinfo 切到 debug
+```
+
+clangd 会自动重新加载（或通过编辑器命令 `clangd: Restart language server` 强制重启）。
+
+---
+
+## 8. 新建项目的最小可用模板
+
+### 8.1 `.clangd`
+
+```yaml
+CompileFlags:
+  CompilationDatabase: build
+  Add: [-std=c++20, -Wall, -Wextra]
+
+Completion:
+  AllScopes: Yes
+  HeaderInsertion: IWYU
+
+Diagnostics:
+  MissingIncludes: Strict
+  UnusedIncludes: Strict
+
+Index:
+  Background: Build
+
+InlayHints:
+  Enabled: Yes
+```
+
+### 8.2 `.clang-format`
+
+```yaml
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+PointerAlignment: Left
+```
+
+### 8.3 `.clang-tidy`
+
+```yaml
+Checks: 'bugprone-*,modernize-*,performance-*,readability-*,-readability-magic-numbers'
+HeaderFilterRegex: '^.*/(src|include)/.*\.(h|hpp)$'
+FormatStyle: file
+```
+
+---
+
+## 9. 常见配置组合速查
+
+| 需求 | 改哪里 |
+|---|---|
+| 切换 build 目录 | `.clangd` 的 `CompileFlags.CompilationDatabase` |
+| 改 C++ 标准（仅影响 clangd） | `.clangd` 的 `CompileFlags.Add: [-std=c++NN]` |
+| 改 C++ 标准（影响实际编译） | `CMakeLists.txt` 的 `set(CMAKE_CXX_STANDARD ...)` |
+| 关闭某个编译警告 | `.clangd` 的 `CompileFlags.Add: [-Wno-xxx]` |
+| 关闭某个 tidy check | `.clang-tidy` 的 `Checks: ... ,-foo-bar` |
+| 改命名风格 | `.clang-tidy` 的 `CheckOptions.readability-identifier-naming.*` |
+| 改缩进/列宽 | `.clang-format` |
+| 改 include 排序 | `.clang-format` 的 `IncludeBlocks` + `IncludeCategories` |
+| 关掉 InlayHints | `.clangd` 的 `InlayHints.Enabled: No` |
+| 关掉某类 InlayHint | `.clangd` 的 `InlayHints.{ParameterNames,DeducedTypes,...}: No` |
+| 三方目录不分析 | `third_party/.clang-tidy` 写 `Checks: '-*'`，或 `.clangd` 用 `If.PathMatch` |
+| MinGW 找不到标准头 | VS Code `clangd.arguments` 加 `--query-driver=...g++.exe` |
+| 没装 .clang-format 的临时风格 | VS Code `clangd.arguments` 加 `--fallback-style=Google` |
+
+---
+
+## 10. 排查问题的顺序
+
+遇到 clangd 行为异常时，按下面的顺序检查：
+
+### Step 1：确认 clangd 真的读到了配置
+
+VS Code 中 `clangd: Open project configuration file` → 看是否打开的是项目根的 `.clangd`。
+
+或者命令行：
+
+```bash
+clangd --check=path/to/file.cpp 2>&1 | head -40
+```
+
+输出会打印它用的编译命令、是否启用了 tidy、配置文件路径。
+
+### Step 2：确认 compile_commands.json 找到了
+
+```bash
+# 看 clangd 用的是哪个 compile_commands.json
+clangd --check=src/foo.cpp 2>&1 | grep -i 'compile_commands'
+```
+
+如果没找到 → 检查 `.clangd` 的 `CompilationDatabase` 路径，或 VS Code 的 `--compile-commands-dir`。
+
+### Step 3：确认 tidy 在跑
+
+打开一个 .cpp 文件，故意写：
+
+```cpp
+int* p = 0;
+```
+
+应该看到 `modernize-use-nullptr` 警告。如果没有 → tidy 没启用。
+
+### Step 4：确认 format 在跑
+
+手动 `Format Document`，看是否按 `.clang-format` 排版。如果不动 → 检查编辑器默认 formatter。
+
+### Step 5：看 clangd 日志
+
+VS Code: `View → Output → clangd`。
+能看到 tidy 启动信息、配置加载顺序、报错原因。
+
+### Step 6：升级 clangd
+
+不少 check 和配置项是新版本才有。`clangd --version` 看一眼，<= 14 的版本很多 check 不可用。
+
+---
+
+## 总结
+
+```
+.clangd          → 控制 clangd 怎么工作（总指挥）
+.clang-format    → 格式化规则（被 clangd 调用）
+.clang-tidy      → 静态检查规则（被 clangd 内嵌运行）
+compile_commands.json → 编译参数数据库（从 CMake 生成）
+```
+
+四份文件各司其职，互不重叠。把它们一起 commit 进版本库，团队所有人 IDE 行为就一致了——这是 clangd 工具链的核心价值。


### PR DESCRIPTION
- .clangd / .clang-format 补充详细中文注释，说明每项作用与可选值
- 新增 .clang-tidy（带注释），启用 bugprone/cert/cppcoreguidelines/ modernize/performance/readability 六大检查组并配置 Google 命名规范
- docs/ 新增四份配置指南：
  · clangd-toolchain-overview.md   工具链整体框架与协作链路
  · clangd-config-guide.md         .clangd 完整配置参考
  · clang-format-config-guide.md   .clang-format 完整配置参考
  · clang-tidy-config-guide.md     .clang-tidy 完整配置参考