### PR TITLE
fix(presets): 让 vcpkg 在 Linux/macOS 上自动检测 triplet，仅 Windows 固化

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,13 +39,12 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "VCPKG_TARGET_TRIPLET": "x64-linux"
+                "CMAKE_CXX_COMPILER": "g++"
             },
             "condition": {
-                "type": "notEquals",
+                "type": "equals",
                 "lhs": "${hostSystemName}",
-                "rhs": "Windows"
+                "rhs": "Linux"
             }
         },
         {
@@ -72,8 +71,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "VCPKG_TARGET_TRIPLET": "x64-linux"
+                "CMAKE_CXX_COMPILER": "clang++"
             },
             "condition": {
                 "type": "notEquals",
@@ -159,9 +157,9 @@
                 "CMAKE_CXX_COMPILER": "g++"
             },
             "condition": {
-                "type": "notEquals",
+                "type": "equals",
                 "lhs": "${hostSystemName}",
-                "rhs": "Windows"
+                "rhs": "Linux"
             }
         },
         {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ ctest   --preset gcc-relwithdebinfo
 切 Clang：把 `gcc-` 换成 `clang-`，并 `apt install -y clang-18 lld-18`（C++23 库依赖
 `libstdc++-13`，已被 g++-13 包带入）。
 
+ARM64 Linux（Raspberry Pi、AWS Graviton 等）同样可用 —— vcpkg 会自动选 `arm64-linux`
+triplet，无需额外配置。
+
+### macOS (Intel / Apple Silicon)
+
+```bash
+# 1) 工具链
+brew install cmake ninja llvm    # llvm 提供较新的 clang；Apple Clang 也可用，但 C++23 滞后
+brew install vcpkg               # 或手动 git clone
+
+# 2) 设置 VCPKG_ROOT
+echo 'export VCPKG_ROOT=$(brew --prefix)/share/vcpkg' >> ~/.zshrc  # brew 安装的话
+source ~/.zshrc
+
+# 3) 构建 + 测试（macOS 上用 clang-* preset；gcc 在 mac 上是 clang shim，不要用 gcc-*）
+cmake --preset clang-relwithdebinfo
+cmake --build --preset clang-relwithdebinfo --parallel
+ctest   --preset clang-relwithdebinfo
+```
+
+vcpkg 会根据主机自动选 `x64-osx`（Intel）或 `arm64-osx`（Apple Silicon），无需手动指定。
+若 Apple Clang 的 C++23 支持不全，请用 `brew install llvm` 后让 PATH 优先指向 LLVM clang。
+
 ### Windows (MSVC / clang-cl)
 
 ```powershell
@@ -87,18 +110,24 @@ clang-cl 同上，preset 改成 `clang-cl-relwithdebinfo`。
 仓库一份 `CMakePresets.json` 同时支持三种主流编译器；与之配套的 vcpkg triplet
 **必须**与编译器 ABI 匹配，否则会出现 GoogleTest 链接失败。
 
+策略：**Linux / macOS 上 vcpkg 会按主机自动检测 triplet**（一种 OS 一种主流 ABI，
+检测可靠），preset 不固化；**Windows 上必须固化**，因为 MSVC ABI 与 MinGW ABI 共存，
+vcpkg 默认猜 `x64-windows`，MinGW 用户需手动覆盖。
+
 | 编译器 | 平台 | vcpkg triplet | preset 前缀 | 备注 |
 | --- | --- | --- | --- | --- |
-| **GCC**          | Linux            | `x64-linux`           | `gcc-*`     | preset 内已固化，且仅在非 Windows 主机上可见 |
+| **GCC**          | Linux x64 / ARM64 | `x64-linux` / `arm64-linux` | `gcc-*` | vcpkg 自动检测；preset 仅在 Linux 主机上可见 |
+| **GCC**          | macOS             | —                     | —           | macOS 上 `gcc` 是 clang shim，请用 `clang-*` preset |
 | **GCC**          | Windows (MinGW)  | `x64-mingw-dynamic`   | `my-gcc-*`  | 需要 `CMakeUserPresets.json` 叠层并 `"condition": null`（见下方 vcpkg 段） |
-| **Clang**        | Linux            | `x64-linux`           | `clang-*`   | preset 内已固化；需要 libstdc++-13 提供 C++23 库 |
+| **Clang**        | Linux x64 / ARM64 | `x64-linux` / `arm64-linux` | `clang-*` | vcpkg 自动检测；需要 libstdc++-13 提供 C++23 库 |
+| **Clang**        | macOS Intel / Apple Silicon | `x64-osx` / `arm64-osx` | `clang-*` | vcpkg 自动检测；preset 在所有非 Windows 主机上可见 |
 | **Clang**        | Windows (MinGW)  | `x64-mingw-dynamic`   | `my-clang-*`| msys2 ucrt64/clang++，方法同 MinGW GCC |
 | **clang-cl**     | Windows (LLVM)   | `x64-windows`         | `clang-cl-*`| preset 内已固化；LLVM 官方分发，需在 VS Developer Prompt 中跑 |
 | **MSVC**         | Windows          | `x64-windows`         | `msvc-*`    | preset 内已固化；VS 2022 multi-config |
 
-仓库 preset 已经把 triplet 固化在 `cacheVariables.VCPKG_TARGET_TRIPLET`，
-正常情况下你不用关心；只有 Windows MinGW 这种"需要 override"的场景才要叠层
-或加 `-D` 覆盖：
+Windows 上的 MSVC / clang-cl preset 已经把 triplet 固化在
+`cacheVariables.VCPKG_TARGET_TRIPLET`，正常情况下你不用关心；只有 Windows MinGW 这种
+"需要 override"的场景才要叠层或加 `-D` 覆盖：
 
 ```bash
 # 方式 A：用本地 CMakeUserPresets.json 叠层（推荐，零环境变量）


### PR DESCRIPTION
## Summary

PR #3 在 `_gcc` / `_clang` preset 上硬编码了 `VCPKG_TARGET_TRIPLET=x64-linux`，并仅以 `hostSystemName != Windows` 作为门控。这让 macOS、ARM64 Linux 等非 Windows 主机也被强制套上 `x64-linux` triplet，反而退化了 vcpkg 之前可靠的主机自动检测。

修复策略基于 ABI 分布：

- **Linux / macOS**：每种 OS 只有一种主流 ABI，vcpkg 主机检测可靠 → preset **不固化** triplet，让 vcpkg 自己根据 OS + 架构选 `x64-linux` / `arm64-linux` / `x64-osx` / `arm64-osx`。
- **Windows**：MSVC ABI 与 MinGW ABI 共存，vcpkg 默认猜 `x64-windows` → MSVC 与 clang-cl preset **保持固化**（它们本来就是 MSVC ABI），MinGW 用户照旧通过 `CMakeUserPresets.json` 叠层覆盖。

## 改动覆盖矩阵

| 主机 | 可用 preset | triplet | 来源 |
| --- | --- | --- | --- |
| Linux x64 | `gcc-*` / `clang-*` | `x64-linux` | vcpkg 自动 |
| Linux ARM64 | `gcc-*` / `clang-*` | `arm64-linux` | vcpkg 自动 |
| macOS Intel | `clang-*` | `x64-osx` | vcpkg 自动 |
| macOS Apple Silicon | `clang-*` | `arm64-osx` | vcpkg 自动 |
| Windows MSVC / clang-cl | `msvc` / `clang-cl-*` | `x64-windows` | preset 固化 |
| Windows MinGW UCRT64 | `my-gcc-*` 叠层 | `x64-mingw-dynamic` | 用户 preset |

## 具体改动

- `_gcc`：去掉 `VCPKG_TARGET_TRIPLET`，condition 收紧为 `hostSystemName == Linux`（macOS 上 `gcc` 是 clang shim）
- `_clang`：去掉 `VCPKG_TARGET_TRIPLET`，condition 保持非 Windows（覆盖 Linux + macOS）
- `_gcc-conan`：condition 同步收紧为 Linux only
- `_clang-conan`：保持非 Windows 不变
- `msvc` / `_clang-cl`：`x64-windows` 不动

README 同步：新增 macOS quickstart，Linux quickstart 注明 ARM64 自动适配，「编译器 × 平台 × triplet 速查」表区分"vcpkg 自动检测"与"preset 固化"。

## Test plan

- [ ] CI: `linux-gcc` 通过（验证 Linux 上去掉固化 triplet 后 vcpkg 自动检测 `x64-linux` 仍工作）
- [ ] CI: `linux-clang` 通过
- [ ] CI: `windows-msvc` 通过（验证 MSVC preset 仍固化 `x64-windows`）
- [ ] CI: `lint` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)