### PR TITLE
docs: 新增 CMake Presets / vcpkg / Conan 三篇入门到实战指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ vcpkg 默认猜 `x64-windows`，MinGW 用户需手动覆盖。
 | **clang-cl**     | Windows (LLVM)   | `x64-windows`         | `clang-cl-*`| preset 内已固化；LLVM 官方分发，需在 VS Developer Prompt 中跑 |
 | **MSVC**         | Windows          | `x64-windows`         | `msvc-*`    | preset 内已固化；VS 2022 multi-config |
 
+> **为什么这样设计**：详见 [`docs/vcpkg-guide.md §5 triplet：ABI 的命名空间`](docs/vcpkg-guide.md#5-tripletabi-的命名空间)。
+
 Windows 上的 MSVC / clang-cl preset 已经把 triplet 固化在
 `cacheVariables.VCPKG_TARGET_TRIPLET`，正常情况下你不用关心；只有 Windows MinGW 这种
 "需要 override"的场景才要叠层或加 `-D` 覆盖：
@@ -168,45 +170,24 @@ cmake --preset gcc-debug
 vcpkg 会读取仓库根的 `vcpkg.json` 自动拉取 `gtest`。Linux / macOS / Windows
 MSVC 到这里就好了，零额外配置。
 
-> **Windows + MinGW GCC/Clang 的一个额外步骤**：vcpkg 在 Windows 上不会检测
-> 当前编译器，总默认 triplet 为 `x64-windows`（MSVC ABI），用它装出来的
-> GoogleTest 与 MinGW GCC 链接时会报大量 `undefined reference to testing::...`。
-> 解决办法：在仓库根建一份 `CMakeUserPresets.json`，给 gcc/clang preset 叠一层
-> triplet 覆盖（`x64-mingw-dynamic`）。已经在 `.gitignore`，不影响仓库：
->
-> 仓库内的 `gcc-*` / `clang-*` preset 已加 `condition: hostSystemName != Windows`
-> （避免 Windows 用户误用 Linux triplet），所以 Windows 上的 MinGW 叠层 preset
-> 必须用 `"condition": null` 显式解除：
+> **Windows + MinGW GCC/Clang 的一个额外步骤**：vcpkg 在 Windows 上不会检测当前
+> 编译器，总默认 triplet 为 `x64-windows`（MSVC ABI），与 MinGW ABI 不匹配会链接失败。
+> 解决办法是在仓库根建一份 `CMakeUserPresets.json`（已 gitignored），叠一层覆盖 triplet
+> 的 `my-*` preset。核心模板：
 >
 > ```json
-> {
->     "version": 6,
->     "configurePresets": [
->         {
->             "name": "_mingw-triplet",
->             "hidden": true,
->             "cacheVariables": { "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic" }
->         },
->         { "name": "my-gcc-debug",   "inherits": ["_mingw-triplet", "gcc-debug"],   "condition": null },
->         { "name": "my-clang-debug", "inherits": ["_mingw-triplet", "clang-debug"], "condition": null }
->     ],
->     "buildPresets": [
->         { "name": "my-gcc-debug",   "configurePreset": "my-gcc-debug" },
->         { "name": "my-clang-debug", "configurePreset": "my-clang-debug" }
->     ],
->     "testPresets": [
->         { "name": "my-gcc-debug",   "configurePreset": "my-gcc-debug",
->           "output": { "outputOnFailure": true, "shortProgress": true } }
->     ]
-> }
+> { "name": "_mingw-triplet", "hidden": true,
+>   "cacheVariables": { "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic" } }
+> { "name": "my-gcc-debug",
+>   "inherits": ["_mingw-triplet", "gcc-debug"], "condition": null }
 > ```
 >
-> 然后用 `cmake --preset my-gcc-debug` 代替 `gcc-debug`。需要 release /
-> relwithdebinfo / minsizerel 就同样照着加一组 `my-*` preset。
->
-> 备选：每次 configure 时手动加 `-DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic`。
->
-> MSVC preset 用默认的 `x64-windows` 即可，不需要 user preset。
+> **完整可用模板（含所有 build types + buildPreset + testPreset）与原理解释**：
+> [`docs/vcpkg-guide.md §6 MinGW 专题`](docs/vcpkg-guide.md#6-mingw-专题)。
+
+> **完整文档**：vcpkg 端到端使用、binary cache、CRT 对齐、排查 FAQ 详见
+> [`docs/vcpkg-guide.md`](docs/vcpkg-guide.md)；preset 设计原理详见
+> [`docs/cmake-presets-guide.md`](docs/cmake-presets-guide.md)。
 
 ### Option B：Conan
 
@@ -234,6 +215,9 @@ ctest --preset gcc-debug-conan
 | GCC   | `gcc-debug-conan` / `gcc-release-conan` / `gcc-relwithdebinfo-conan` |
 | Clang | `clang-debug-conan` / `clang-release-conan` / `clang-relwithdebinfo-conan` |
 | MSVC  | `msvc-conan`（多配置）+ build/test preset `msvc-{debug,release,relwithdebinfo}-conan` |
+
+> **完整文档**：Conan 2.x 概念、profile、CMakeDeps/CMakeToolchain、三步走工作流、
+> 排查 FAQ 详见 [`docs/conan-guide.md`](docs/conan-guide.md)。
 
 ---
 

--- a/docs/cmake-presets-guide.md
+++ b/docs/cmake-presets-guide.md
@@ -1,0 +1,652 @@
+# CMake Presets 使用与配置完整指南
+
+> 本文档系统讲解 CMake Presets 的设计理念、文件结构、继承机制、condition 系统、与
+> toolchain 的衔接，以及本仓库的 `CMakePresets.json` 是如何把多编译器（gcc / clang /
+> clang-cl / MSVC）+ 多构建类型 + 多依赖管理器（vcpkg / Conan）组织起来的。
+>
+> 配套文件：[`CMakePresets.json`](../CMakePresets.json)
+>
+> 配套阅读：
+> - [`docs/vcpkg-guide.md`](vcpkg-guide.md) —— vcpkg 端到端
+> - [`docs/conan-guide.md`](conan-guide.md) —— Conan 端到端
+> - [`docs/ci-guide.md`](ci-guide.md) —— CI 怎么按 preset 名展开 matrix
+
+---
+
+## 目录
+
+1. [什么是 CMake Presets，为什么需要它](#1-什么是-cmake-presets为什么需要它)
+2. [文件结构与 schema 速览](#2-文件结构与-schema-速览)
+3. [hidden + inherits：组合优于复制](#3-hidden--inherits组合优于复制)
+4. [本仓库 preset 全景图](#4-本仓库-preset-全景图)
+5. [condition：让 preset 跨平台共存](#5-condition让-preset-跨平台共存)
+6. [多配置 vs 单配置生成器](#6-多配置-vs-单配置生成器)
+7. [testPresets 与 _test-base 的设计](#7-testpresets-与-_test-base-的设计)
+8. [toolchain hook 机制](#8-toolchain-hook-机制)
+9. [CMakeUserPresets.json：本地叠层](#9-cmakeuserpresetsjson本地叠层)
+10. [常见问题与排查](#10-常见问题与排查)
+
+---
+
+## 1. 什么是 CMake Presets，为什么需要它
+
+**CMake Presets** 是 CMake 3.19 引入的"命令固化机制"：把原本要写在命令行里的一长串
+`-G`、`-D`、环境变量、toolchain 路径等，全部写进一份 `CMakePresets.json`，开发者用一行
+`cmake --preset <名字>` 就能复现完整配置。
+
+### 没有 preset 的世界
+
+```bash
+# 每个开发者要记住自己平台的完整命令
+cmake -S . -B build/gcc-debug \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_COMPILER=gcc \
+    -DCMAKE_CXX_COMPILER=g++ \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+    -DVCPKG_TARGET_TRIPLET=x64-linux
+```
+
+问题一大堆：
+
+- 命令贴错一个字符就能整天 debug
+- 团队里每个人/每个 IDE 写法不同，CI 又是另一套
+- 切编译器要重抄一遍
+- 新人入门门槛高
+
+### 有 preset 的世界
+
+```bash
+cmake --preset gcc-debug
+cmake --build --preset gcc-debug
+ctest --preset gcc-debug
+```
+
+三行命令在所有平台、所有 IDE、CI 全部一样。配置细节都进了版本管理的 JSON。
+
+### preset 在本项目的价值
+
+本项目同时支持 **GCC / Clang / clang-cl / MSVC** 四套编译器、**Debug / Release /
+RelWithDebInfo / MinSizeRel** 四种构建类型、**vcpkg / Conan** 两种依赖管理器，组合爆炸。
+preset 把每个组合凝固成一个名字，开发者只需要记编译器+构建类型，例如
+`clang-relwithdebinfo`、`msvc-debug-conan`。
+
+CI（[ci.yml](../.github/workflows/ci.yml)）也直接复用这套 preset 名 —— **本地与 CI
+使用完全一样的配置**，本地通过的代码 CI 不会因配置差异而失败。
+
+---
+
+## 2. 文件结构与 schema 速览
+
+`CMakePresets.json` 的最小骨架：
+
+```json
+{
+    "version": 6,
+    "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
+    "configurePresets": [ ... ],
+    "buildPresets":     [ ... ],
+    "testPresets":      [ ... ]
+}
+```
+
+### 顶层字段
+
+| 字段 | 含义 | 本仓库取值 |
+| --- | --- | --- |
+| `version` | preset schema 版本，决定能用哪些字段 | `6`（支持 condition、$env 等较新特性） |
+| `cmakeMinimumRequired` | 最低 CMake 版本，不满足直接报错 | `3.25` |
+| `configurePresets` | configure 阶段的 preset 数组 | 7 个 hidden + 17 个 leaf |
+| `buildPresets` | build 阶段的 preset 数组 | 22 个 |
+| `testPresets` | ctest 的 preset 数组 | 1 个 hidden + 22 个 |
+
+> schema 版本越高功能越多，但需要更新的 CMake。`version: 6` 要求 CMake ≥ 3.25。本仓库
+> `cmakeMinimumRequired` 已经卡到 3.25，所以可以放心用 `condition`、`$env` 这些 v3+
+> 才有的字段。
+
+### 三类 preset 各自管什么
+
+```
+configurePreset  →  cmake --preset <name>
+                    决定：generator / compiler / toolchain / cacheVariables
+
+buildPreset      →  cmake --build --preset <name>
+                    引用一个 configurePreset，可指定 configuration / target
+
+testPreset       →  ctest --preset <name>
+                    引用一个 configurePreset，控制 ctest 行为
+```
+
+三类 preset **可以同名**（CMake 按使用阶段区分）。本仓库 `gcc-debug` 既是
+configurePreset 也是 buildPreset 也是 testPreset，名字共用，开发者一个名字打通三步。
+
+---
+
+## 3. hidden + inherits：组合优于复制
+
+如果每个 leaf preset 都把 generator、compiler、toolchain、cacheVariables 全写一遍，
+24 个 preset 就要重复 24 次相同的字段。**`hidden` + `inherits` 让你把公共字段抽出来当
+积木**。
+
+### `hidden: true` 的作用
+
+```json
+{
+    "name": "_base",
+    "hidden": true,
+    "binaryDir": "${sourceDir}/build/${presetName}",
+    "cacheVariables": { "CMAKE_EXPORT_COMPILE_COMMANDS": "ON" }
+}
+```
+
+`hidden: true` 表示这个 preset 是**积木，不是入口**。它：
+
+- **不会**出现在 `cmake --list-presets`
+- **不能**直接 `cmake --preset _base`（CMake 会报错说 preset 是 hidden 的）
+- **可以**被其他 preset `inherits`
+
+约定俗成用下划线开头（`_base` / `_vcpkg` / `_gcc`），跟普通 leaf 视觉区分。
+
+### `inherits` 的合并语义
+
+```json
+{
+    "name": "gcc-debug",
+    "inherits": "_gcc",
+    "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+}
+```
+
+`inherits` 可以是字符串或数组：
+
+- **字符串**：单继承，从一个 hidden preset 拿字段
+- **数组**：多继承，按顺序合并；后者覆盖前者
+
+合并规则（重要）：
+
+| 字段类型 | 合并方式 |
+| --- | --- |
+| `cacheVariables`（对象） | **浅合并**，子 preset 同名 key 覆盖父的 |
+| `environment`（对象） | 浅合并 |
+| `generator` / `binaryDir` 等标量 | 子有则覆盖，子无则继承 |
+| `condition` | **不继承**！每个 preset 自己判断 |
+
+> `condition` 不继承这条很关键 —— 父 preset 的 condition 不会自动传到子 preset。本仓库
+> 的做法是：**hidden 中间层带 condition**，leaf 不写 condition，而 CMake 实际行为是把
+> hidden 父级的 condition 视为 leaf 是否可见的前置条件（v3.21+ 表现一致）。如果将来
+> CMake 规则收紧，需要把 condition 往 leaf 上抄。
+
+### 本仓库的三层结构
+
+```
+                       ┌─────────────────────────┐
+                       │       _base             │  ← binaryDir + compile_commands
+                       └─────────────────────────┘
+                                  │
+                ┌─────────────────┼─────────────────┐
+                │                                   │
+        ┌───────▼──────┐                    ┌──────▼──────┐
+        │   _vcpkg     │                    │   _conan    │   ← toolchain 注入
+        └───────┬──────┘                    └──────┬──────┘
+                │                                  │
+       ┌────────┼────────┐                ┌────────┼────────┐
+       │        │        │                │        │        │
+   ┌───▼──┐ ┌──▼──┐ ┌────▼─────┐    ┌────▼────┐ ┌─▼──────┐ │
+   │ _gcc │ │_clang│ │_clang-cl │    │_gcc-conan│ │_clang- │ ...
+   └───┬──┘ └──┬──┘ └────┬─────┘    └────┬────┘ │ conan  │
+       │       │         │               │      └────┬───┘
+   ┌───▼───┐   …         …               …           …
+   │gcc-   │
+   │debug  │  ← leaf：只填 CMAKE_BUILD_TYPE
+   └───────┘
+```
+
+第一层（`_base`）管"所有 preset 都需要"的设置；第二层（`_vcpkg` / `_conan`）管
+toolchain；第三层（`_gcc` / `_clang` / ...）管编译器和 generator；leaf 只填构建类型。
+
+**新增一个构建类型** 只要加一个 leaf；**新增一个编译器** 加一个第三层的 hidden + 4 个
+leaf；**新增一种依赖管理器** 加一个第二层 hidden + 复制一组第三层。
+
+---
+
+## 4. 本仓库 preset 全景图
+
+> 本节是仓库 preset JSON 的**唯一权威展示**位置，其他文档只展示片段并反向链接到这里。
+
+### 第一层：`_base`
+
+```json
+{
+    "name": "_base",
+    "hidden": true,
+    "binaryDir": "${sourceDir}/build/${presetName}",
+    "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+    }
+}
+```
+
+- `${sourceDir}` / `${presetName}` 是 CMake 内置宏，分别展开为源码目录与当前 preset 名
+- `binaryDir` 模板让每个 preset 各占一个 `build/<presetName>/` 目录，互不干扰
+- `compile_commands.json` 给 clangd 用（详见 [clangd-toolchain-overview.md](clangd-toolchain-overview.md)）
+
+### 第二层：`_vcpkg` 与 `_conan`
+
+```json
+{
+    "name": "_vcpkg",
+    "hidden": true,
+    "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    }
+}
+
+{
+    "name": "_conan",
+    "hidden": true,
+    "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build/${presetName}/conan_toolchain.cmake"
+    }
+}
+```
+
+两个 toolchain 注入策略的差别：
+
+- vcpkg 走 **环境变量** `$env{VCPKG_ROOT}` —— 一台机器只有一个 vcpkg root，每个用户
+  自己设环境变量
+- Conan 走 **per-preset 路径** —— Conan 的 toolchain 是 `conan install` 命令产物，按
+  preset 隔离
+
+详见 [§8 toolchain hook 机制](#8-toolchain-hook-机制)。
+
+### 第三层：编译器 hidden 中间层
+
+```json
+{
+    "name": "_gcc",
+    "hidden": true,
+    "inherits": ["_vcpkg", "_base"],
+    "generator": "Ninja",
+    "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+    },
+    "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+    }
+}
+```
+
+`inherits` 数组顺序：`_vcpkg` 先，`_base` 后 —— 后者覆盖前者，但二者无字段冲突，顺序
+其实不影响。习惯把"主要功能"（toolchain）写前面，把"通用基础"（_base）写后面。
+
+`condition` 把这个 hidden 限定在 Linux 主机上，详见 [§5](#5-condition让-preset-跨平台共存)。
+
+类似地：
+
+- `_clang`：与 `_gcc` 同模板，编译器换成 `clang/clang++`，condition 改为 `notEquals Windows`（覆盖 Linux + macOS）
+- `_clang-cl`：condition 为 `equals Windows`，且固化 `VCPKG_TARGET_TRIPLET: x64-windows`
+- `_gcc-conan` / `_clang-conan`：换 `inherits` 为 `["_conan", "_base"]`，condition 同上
+
+### 第四层：leaf
+
+```json
+{
+    "name": "gcc-debug",
+    "displayName": "GCC Debug",
+    "inherits": "_gcc",
+    "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+}
+```
+
+leaf 的内容**只有构建类型**。其他全部从 `_gcc` 链上继承。这就是分层的回报。
+
+### MSVC 是个特例：单 configurePreset + 多 buildPreset
+
+详见 [§6 多配置 vs 单配置生成器](#6-多配置-vs-单配置生成器)。
+
+### 完整 leaf 一览
+
+| 编译器 | leaf 名 | 数量 |
+| --- | --- | --- |
+| GCC | `gcc-{debug,release,relwithdebinfo,minsizerel}` | 4 |
+| Clang | `clang-{debug,release,relwithdebinfo,minsizerel}` | 4 |
+| clang-cl | `clang-cl-{debug,release,relwithdebinfo,minsizerel}` | 4 |
+| MSVC | `msvc`（多配置） | 1 |
+| GCC + Conan | `gcc-{debug,release,relwithdebinfo}-conan` | 3 |
+| Clang + Conan | `clang-{debug,release,relwithdebinfo}-conan` | 3 |
+| MSVC + Conan | `msvc-conan`（多配置） | 1 |
+| **合计 configurePreset** | | **20** |
+
+### 命名约定
+
+- vcpkg 版：`{compiler}-{buildtype}`（例：`gcc-debug`）
+- Conan 版：`{compiler}-{buildtype}-conan`（例：`gcc-debug-conan`）
+- 多配置：仅编译器名（例：`msvc`、`msvc-conan`）
+
+---
+
+## 5. condition：让 preset 跨平台共存
+
+### 为什么需要 condition
+
+仓库一份 `CMakePresets.json` 同时承载 Linux、macOS、Windows 三类主机的 preset。如果 Windows
+用户能看到 `gcc-debug`（Linux 的 GCC preset），他可能误用 —— configure 出错事小，**用
+错误的 vcpkg triplet 把 gtest 装出来再链接失败**事大。
+
+`condition` 让 preset **在不满足条件的主机上不出现**：`cmake --list-presets` 不列出，
+`cmake --preset` 报错说找不到。
+
+### 语法
+
+```json
+"condition": {
+    "type": "equals",
+    "lhs": "${hostSystemName}",
+    "rhs": "Linux"
+}
+```
+
+`type` 常用：
+
+- `equals` / `notEquals`：比较两个字符串
+- `inList` / `notInList`：判断 lhs 是否在 rhs 列表里
+- `matches`：lhs 匹配 rhs 正则
+- `anyOf` / `allOf`：组合多个条件
+- `not`：取反
+
+`${hostSystemName}` 是 CMake 内置宏，展开为 `Linux` / `Darwin`（macOS）/ `Windows`。
+
+### 本仓库的条件分布
+
+| Hidden preset | condition | 含义 |
+| --- | --- | --- |
+| `_gcc` / `_gcc-conan` | `${hostSystemName}` equals `Linux` | 仅 Linux —— macOS 上 `gcc` 是 clang shim，避免误用 |
+| `_clang` / `_clang-conan` | `${hostSystemName}` notEquals `Windows` | Linux + macOS（macOS 用 Apple Clang） |
+| `msvc` / `_clang-cl` | `${hostSystemName}` equals `Windows` | 仅 Windows |
+
+历史背景：早期版本只用 `notEquals Windows`，但这覆盖了 macOS，被代码评审指出 macOS
+应该走 `clang-*` 而不是 `gcc-*`。详见 PR #5。
+
+### condition 不满足时的表现
+
+```bash
+# 在 Windows 上跑：
+$ cmake --preset gcc-debug
+CMake Error: No such preset in CMakePresets.json: "gcc-debug"
+
+$ cmake --list-presets
+Available configure presets:
+  "msvc"            - MSVC (VS 2022, multi-config)
+  "clang-cl-debug"  - clang-cl Debug
+  ...
+# 注意：gcc-* 与 clang-* 都不会出现
+```
+
+### MinGW 用户怎么办
+
+MinGW（msys2 ucrt64 环境）虽然在 Windows 上，但用 GNU 工具链 + GNU ABI。本仓库的
+`_gcc` 在 Windows 上不可见，这正是 condition 想避免的"误用"。MinGW 用户的正确做法是
+在本地 [`CMakeUserPresets.json`](#9-cmakeuserpresetsjson本地叠层) 里叠一层带
+`"condition": null` 的 leaf，详见 [vcpkg-guide.md §6 MinGW 专题](vcpkg-guide.md#6-mingw-专题)。
+
+---
+
+## 6. 多配置 vs 单配置生成器
+
+CMake 的 generator 分两类：
+
+- **单配置**（Ninja、Makefile）：configure 时就要决定 `CMAKE_BUILD_TYPE`，每个构建类型
+  一份独立的 build 目录
+- **多配置**（Visual Studio、Xcode）：configure 一次生成"工程文件"，**构建时**通过
+  `--config Debug/Release` 选构建类型
+
+本仓库都用到了。
+
+### 单配置（gcc / clang / clang-cl）
+
+```bash
+cmake --preset gcc-debug              # configure 出 build/gcc-debug/
+cmake --build --preset gcc-debug      # 构建 Debug
+cmake --preset gcc-release            # 单独 configure 出 build/gcc-release/
+cmake --build --preset gcc-release    # 构建 Release
+```
+
+每个构建类型一个 leaf preset，互不干扰。优点：不同构建类型的 build artifact 不会冲突。
+缺点：preset 数量多（4 build types × 3 编译器 = 12 个）。
+
+### 多配置（MSVC / Visual Studio）
+
+```json
+{
+    "name": "msvc",
+    "displayName": "MSVC (VS 2022, multi-config)",
+    "generator": "Visual Studio 17 2022",
+    "architecture": { "value": "x64", "strategy": "set" },
+    "cacheVariables": { "VCPKG_TARGET_TRIPLET": "x64-windows" }
+}
+```
+
+```bash
+cmake --preset msvc                          # configure 一次（生成 .sln 工程）
+cmake --build --preset msvc-debug            # 构建 Debug
+cmake --build --preset msvc-release          # 构建 Release
+cmake --build --preset msvc-relwithdebinfo   # 构建 RelWithDebInfo
+```
+
+只有一个 configurePreset，但有四个 buildPreset：
+
+```json
+{ "name": "msvc-debug",          "configurePreset": "msvc", "configuration": "Debug" },
+{ "name": "msvc-release",        "configurePreset": "msvc", "configuration": "Release" },
+{ "name": "msvc-relwithdebinfo", "configurePreset": "msvc", "configuration": "RelWithDebInfo" },
+{ "name": "msvc-minsizerel",     "configurePreset": "msvc", "configuration": "MinSizeRel" }
+```
+
+`configuration` 字段就是 `--config` 的等价物。
+
+### 为什么不全用一种
+
+- **Ninja 单配置**：构建快、跨平台、与 clangd 配合好（一个 `compile_commands.json` 不混淆）
+- **VS 多配置**：能直接在 Visual Studio IDE 里切构建类型；MSVC 用户更习惯
+
+仓库同时提供两套，让用户按自己的工作流选。
+
+---
+
+## 7. testPresets 与 _test-base 的设计
+
+`testPresets` 控制 `ctest` 的行为。本仓库把所有 testPreset 共用的设置抽到一个
+hidden base：
+
+```json
+{
+    "name": "_test-base",
+    "hidden": true,
+    "output": { "outputOnFailure": true, "shortProgress": true },
+    "execution": { "noTestsAction": "ignore", "stopOnFailure": false }
+}
+```
+
+- `outputOnFailure`：测试失败时打印 stdout（默认只显示 PASS/FAIL）
+- `shortProgress`：进度条简洁形式
+- `noTestsAction: ignore`：模块没注册测试时不报错（demo-only 模块常见）
+- `stopOnFailure: false`：单个测试挂了继续跑后面的
+
+每个 leaf testPreset 只需写：
+
+```json
+{ "name": "gcc-debug", "inherits": "_test-base", "configurePreset": "gcc-debug" }
+```
+
+### `ctest --preset` vs `cmake --build --preset && ctest`
+
+```bash
+# 方式 A（推荐）：直接 ctest --preset
+ctest --preset gcc-debug
+
+# 方式 B：手动 ctest，需要 cd 到 build 目录
+cd build/gcc-debug && ctest --output-on-failure
+```
+
+方式 A 的好处：所有 ctest 选项已经在 preset 里固化，开发者不需要记。CI 也用方式 A。
+
+---
+
+## 8. toolchain hook 机制
+
+> 这是 preset 与 vcpkg/Conan 衔接的核心机制。vcpkg-guide 与 conan-guide 都会反向引用
+> 这一节。
+
+### `CMAKE_TOOLCHAIN_FILE` 的本质
+
+CMake 在第一次 `project()` 调用之前，会**先加载** `CMAKE_TOOLCHAIN_FILE` 指向的 .cmake
+文件。这个文件可以：
+
+- 设置编译器路径
+- 注入 `find_package` 的搜索路径
+- 设置目标架构、CRT、运行时库
+- 触发依赖安装（vcpkg manifest 模式就是利用这一点）
+
+这是一个 **"在编译还没开始之前就改造 CMake"** 的钩子。包管理器全靠它接入 CMake。
+
+### vcpkg 的 hook：`vcpkg.cmake`
+
+```json
+"CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+```
+
+- `$env{VCPKG_ROOT}` 是 preset 的环境变量展开宏，读取 shell 里的 `VCPKG_ROOT`
+- `vcpkg.cmake` 在 configure 时会：
+  1. 读 `vcpkg.json`（manifest 模式）
+  2. 决定 triplet（来自 `VCPKG_TARGET_TRIPLET` 或主机自动检测）
+  3. 安装缺失依赖（首次 configure 慢就是因为这一步）
+  4. 把 vcpkg 的 install 目录加进 `CMAKE_PREFIX_PATH`，让 `find_package` 能找到
+
+详见 [vcpkg-guide.md §4](vcpkg-guide.md#4-toolchain-文件的工作机制)。
+
+### Conan 的 hook：`conan_toolchain.cmake`
+
+```json
+"CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build/${presetName}/conan_toolchain.cmake"
+```
+
+- 路径硬编码到 `build/<presetName>/` —— 因为 Conan 的 toolchain 是 **`conan install`
+  命令的产物**，必须先跑 `conan install` 再跑 `cmake --preset`
+- `conan_toolchain.cmake` 由 Conan 的 `CMakeToolchain` generator 写出
+- 它把编译器、build_type、libcxx ABI 等翻译成 CMake 变量，并把 Conan 的 install
+  目录加进 `CMAKE_PREFIX_PATH`
+
+详见 [conan-guide.md §4](conan-guide.md#4-cmakedeps-与-cmaketoolchain-两个-generator)。
+
+### 两种策略对比
+
+| 维度 | vcpkg | Conan |
+| --- | --- | --- |
+| toolchain 来源 | 仓库自带（git clone） | 命令产物（`conan install` 生成） |
+| preset 路径写法 | `$env{VCPKG_ROOT}/...` | `${sourceDir}/build/${presetName}/...` |
+| 是否需要预步骤 | 否（`cmake --preset` 一步触发） | 是（必须先 `conan install`） |
+| 多 preset 共享 | 一份 toolchain 文件 | per-preset 各一份 |
+
+---
+
+## 9. CMakeUserPresets.json：本地叠层
+
+`CMakeUserPresets.json` 是 CMake 给个人用户准备的"叠层文件"：
+
+- **不入库**（本仓库 `.gitignore` 已忽略）
+- 与 `CMakePresets.json` 同目录
+- CMake 加载时会把两份文件**合并**，叠层 preset 可以 `inherits` 仓库 preset
+
+### 典型用途
+
+- **MinGW 用户**：覆盖 vcpkg triplet 为 `x64-mingw-dynamic`（详见 [vcpkg-guide.md §6](vcpkg-guide.md#6-mingw-专题)）
+- **本地编译器路径不在 PATH 里**：覆盖 `CMAKE_C_COMPILER` 为绝对路径
+- **个人偏好的 build 目录布局**：覆盖 `binaryDir`
+- **添加只对自己有用的 leaf**：例如带特殊 sanitizer 配置的 `my-debug-asan`
+
+### 与仓库 preset 的合并规则
+
+- 同名 preset：UserPresets 里的字段**覆盖**仓库版（按 cacheVariables 浅合并）
+- 不同名 preset：直接追加，能 `inherits` 仓库的 hidden preset
+
+### MinGW 叠层模板（核心 5 行）
+
+```json
+{
+    "name": "_mingw-triplet",
+    "hidden": true,
+    "cacheVariables": { "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic" }
+}
+```
+
+完整可用模板（含 leaf、condition: null、buildPreset、testPreset）见
+[vcpkg-guide.md §6 MinGW 专题](vcpkg-guide.md#6-mingw-专题)。
+
+---
+
+## 10. 常见问题与排查
+
+### "No such preset in CMakePresets.json"
+
+可能原因：
+
+1. **拼错 preset 名**：跑 `cmake --list-presets` 核对
+2. **condition 不满足**：你在 Windows 上找 `gcc-debug`，但它被门控为 Linux-only。
+   `--list-presets` 不会列出来，但 `--list-presets all` 会列出**含 hidden 与不满足
+   condition 的所有 preset**，可用来确认是被 condition 挡住了
+3. **CMake 版本太低**：仓库要求 ≥ 3.25，旧版本不认 `version: 6` 直接失败
+4. **`hidden: true` 的 preset 想直接用**：hidden 只能被 inherits，不能 `--preset`
+
+### inherits 顺序导致 cacheVariables 被覆盖
+
+```json
+"inherits": ["_a", "_b"]
+```
+
+后者（`_b`）的同名 cacheVariable 会覆盖前者（`_a`）。本仓库习惯：通用基础（`_base`）
+放后面，主要功能（`_vcpkg` / `_conan`）放前面。如果 `_base` 不小心定义了 toolchain，
+就会把 `_vcpkg` 的 toolchain 覆盖掉。**修改 inherits 顺序前先确认两个 preset 没有
+字段冲突**。
+
+### IDE 识别 preset 的注意事项
+
+- **VSCode + CMake Tools 扩展**：右下角能切 preset；如果改了 JSON 没生效，
+  Ctrl+Shift+P → "CMake: Reset CMake Tools Extension State"
+- **CLion**：File → Settings → Build, Execution, Deployment → CMake，启用 "CMakePresets.json"
+- **Visual Studio**：原生支持 preset，但 condition 解析有差异，可能比命令行多/少几个
+
+### `${env}` vs `$env{}` 不一样
+
+- `$env{NAME}`：preset 字段里的环境变量展开，**configure 时一次性展开为字符串**
+- `$ENV{NAME}`（CMake script 里）：CMake 脚本里的运行时读取，是另一个语境
+
+写 preset 时统一用 `$env{}`。
+
+### 改 preset 后必须重新 configure
+
+```bash
+# 改 CMakePresets.json 后：
+rm -rf build/gcc-debug   # 旧的 CMakeCache.txt 会缓存上次 configure 的结果
+cmake --preset gcc-debug
+```
+
+`CMakeCache.txt` 一旦生成，CMake 不会重新读 toolchain 文件、不会重算 condition。改
+preset 不重新 configure 是 CMake 用户最常踩的坑。
+
+### CI 与本地 preset 怎么对应
+
+CI 直接用 preset 名作 matrix entry：
+
+```yaml
+matrix:
+  include:
+    - { name: linux-gcc, preset: gcc-relwithdebinfo, ... }
+    - { name: linux-clang, preset: clang-relwithdebinfo, ... }
+```
+
+CI 跑的就是 `cmake --preset $preset` —— 与你本地命令一字不差。详见
+[ci-guide.md §5 Matrix 并行策略](ci-guide.md#5-matrix-并行策略)。

--- a/docs/conan-guide.md
+++ b/docs/conan-guide.md
@@ -1,0 +1,719 @@
+# Conan 使用与配置完整指南
+
+> 本文档系统讲解 Conan 2.x 的设计理念、profile 概念、conanfile.txt 配置、CMakeDeps 与
+> CMakeToolchain generator、cmake_layout，以及本仓库 `conanfile.txt` 是如何与 CMake
+> Presets 衔接的。
+>
+> 配套文件：[`conanfile.txt`](../conanfile.txt) / [`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake)
+>
+> 配套阅读：
+> - [`docs/cmake-presets-guide.md`](cmake-presets-guide.md) —— preset 与 toolchain hook 机制
+> - [`docs/vcpkg-guide.md`](vcpkg-guide.md) —— 平行的另一种方案
+> - [`docs/ci-guide.md`](ci-guide.md) —— CI 当前未集成 Conan，本文 §9 说明原因
+
+---
+
+## 目录
+
+1. [什么是 Conan，它解决什么问题](#1-什么是-conan它解决什么问题)
+2. [安装与 profile 初始化](#2-安装与-profile-初始化)
+3. [conanfile.txt 详解](#3-conanfiletxt-详解)
+4. [CMakeDeps 与 CMakeToolchain 两个 generator](#4-cmakedeps-与-cmaketoolchain-两个-generator)
+5. [cmake_layout 与 per-preset 输出目录](#5-cmake_layout-与-per-preset-输出目录)
+6. [本仓库工作流](#6-本仓库工作流)
+7. [编译器矩阵下的 preset 设计](#7-编译器矩阵下的-preset-设计)
+8. [profile 进阶](#8-profile-进阶)
+9. [与 CI 的集成（前瞻）](#9-与-ci-的集成前瞻)
+10. [常见问题与排查](#10-常见问题与排查)
+
+---
+
+## 1. 什么是 Conan，它解决什么问题
+
+**Conan** 是 JFrog 主导的 C/C++ 包管理器。Conan 2.x 与 1.x 是不兼容的两套，本仓库
+（与本文档）只讲 **Conan 2.x**。
+
+Conan 的核心理念：用 Python 写的 **recipe**（`conanfile.py`）描述如何构建一个包，用
+**profile** 描述构建环境（编译器、build_type、libcxx ABI 等），二者结合产生一个
+**package_id** 索引到具体的二进制。Conan 默认会先去远端 binary repo 拉对应
+package_id 的二进制，没有才本地 build。
+
+### vcpkg vs Conan 对比表
+
+> 这是本仓库选 vcpkg+Conan 双轨支持的对照表，[vcpkg-guide.md §1](vcpkg-guide.md#1-什么是-vcpkg它解决什么问题)
+> 反向引用此处。
+
+| 维度 | vcpkg | Conan |
+| --- | --- | --- |
+| 包格式 | port（CMake/PowerShell 脚本） | recipe（Python，`conanfile.py`） |
+| 二进制分发 | 默认无（源码编译，可选 binary cache） | **默认有**（远端有 prebuilt 直接拉） |
+| ABI 描述 | triplet 字符串（`x64-windows-static`） | profile（多字段：compiler/version/libcxx/build_type/...） |
+| 项目清单 | `vcpkg.json`（manifest 模式） | `conanfile.txt` 或 `conanfile.py` |
+| 与 CMake 衔接 | 单一 toolchain `vcpkg.cmake`，cmake configure 一步触发 | 两个 generator（toolchain + deps），需先 `conan install` |
+| 版本范围语法 | `version>=` 等基础约束 | 完整范围语法（`[>=1.10 <2.0]` 等） |
+| 多版本共存 | 通过 overlay ports | 内置（同一包多 version 可共存于 cache） |
+| 学习曲线 | 较低（manifest + 一个 toolchain 就懂） | 较高（profile/recipe/cache 三个新概念） |
+
+一句话定位：**vcpkg 像 apt（编译型）；Conan 像 Maven（recipe + 二进制分发）**。
+
+### 为什么本仓库同时支持两种
+
+教学项目，目的是让读者**体验两种生态**。日常工作选一个就好：
+
+- 团队内 C++ 项目、Windows 居多 → vcpkg 更顺
+- 跨语言（含 C++）大型项目、有 binary repo → Conan 更顺
+
+---
+
+## 2. 安装与 profile 初始化
+
+### 安装 Conan 2.x
+
+```bash
+# pip 是官方推荐方式
+pip install --upgrade conan
+
+# 验证版本（必须 ≥ 2.0）
+conan --version
+# Conan version 2.x.x
+```
+
+> 不要用 `conan` 1.x 的资料 —— 1.x 与 2.x 命令、配置、generator 全不兼容。判定标准：
+> 命令 `conan profile detect` 在 1.x 不存在。
+
+### 首次 profile 初始化
+
+```bash
+conan profile detect
+# Found gcc 13
+# gcc>=11 && libstdc++ -> setting libstdc++11
+# Detected profile:
+# [settings]
+# arch=x86_64
+# build_type=Release
+# compiler=gcc
+# compiler.cppstd=gnu17
+# compiler.libcxx=libstdc++11
+# compiler.version=13
+# os=Linux
+```
+
+`conan profile detect` 检测当前主机环境，写入默认 profile（位置见
+`conan profile path default`）。这个 profile 会作为后续 `conan install` 的默认
+**host profile**。
+
+### profile 文件结构
+
+profile 是 INI 格式：
+
+```ini
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=13
+os=Linux
+
+[options]
+# 包级 options 覆盖
+
+[buildenv]
+# 构建期环境变量
+
+[runenv]
+# 运行期环境变量
+
+[conf]
+# 配置项（tools.cmake.cmaketoolchain:generator 等）
+```
+
+### profile 与 vcpkg triplet 的对照
+
+| vcpkg triplet | Conan settings 等价 |
+| --- | --- |
+| `x64-linux` | `arch=x86_64`, `os=Linux`, `compiler.libcxx=libstdc++11` |
+| `arm64-linux` | `arch=armv8`, `os=Linux`, `compiler.libcxx=libstdc++11` |
+| `x64-windows` | `arch=x86_64`, `os=Windows`, `compiler=msvc`, `compiler.runtime=dynamic` |
+| `x64-mingw-dynamic` | `arch=x86_64`, `os=Windows`, `compiler=gcc`, `compiler.libcxx=libstdc++11` |
+| `x64-osx` | `arch=x86_64`, `os=Macos`, `compiler.libcxx=libc++` |
+
+triplet 用一个字符串编码，profile 用多字段表达 —— **profile 表达力更强**（可分
+host/build profile 做交叉编译，可分 compiler.libcxx 与 libcxx ABI 等），代价是新概念
+更多。
+
+---
+
+## 3. conanfile.txt 详解
+
+本仓库的 `conanfile.txt` 全文：
+
+```ini
+[requires]
+gtest/1.15.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout
+```
+
+### 字段解释
+
+#### `[requires]`：依赖列表
+
+```ini
+[requires]
+gtest/1.15.0
+fmt/[>=10.0 <11.0]
+boost/1.84.0
+```
+
+- 一行一个依赖，格式 `name/version`
+- 版本可以是精确版本（`1.15.0`）或范围（`[>=10.0 <11.0]`、`[*]`）
+- 不写 version Conan 会拒绝（与 vcpkg 不同，vcpkg 不写就用 baseline 默认）
+
+#### `[generators]`：CMake 集成 generator
+
+| Generator | 产物 | 作用 |
+| --- | --- | --- |
+| `CMakeDeps` | `<pkg>-config.cmake` 等 | 让 `find_package(GTest CONFIG)` 找到 |
+| `CMakeToolchain` | `conan_toolchain.cmake` | 把 profile 翻译成 CMake 变量 |
+
+详见 [§4](#4-cmakedeps-与-cmaketoolchain-两个-generator)。
+
+#### `[layout]`：输出目录布局
+
+`cmake_layout` 是 Conan 内置的标准布局，详见 [§5](#5-cmake_layout-与-per-preset-输出目录)。
+
+#### 其他字段（本仓库未用）
+
+```ini
+[options]
+boost*:shared=True
+
+[build_requires]
+cmake/3.27.0
+
+[tool_requires]
+ninja/1.11.0
+
+[test_requires]
+catch2/3.4.0
+```
+
+- `[options]`：覆盖包的 options
+- `[build_requires]` / `[tool_requires]`：构建时才需要的工具（cmake / ninja 等）
+- `[test_requires]`：测试时才用的依赖
+
+### conanfile.py vs conanfile.txt
+
+Conan 支持两种格式：
+
+- **conanfile.txt**：INI 格式，简单声明，适合"我只是消费别人的包"
+- **conanfile.py**：Python 类，能写自定义 build 逻辑，适合"我要自己产出包"
+
+**本仓库选 `.txt`**，因为它是消费方（不发布包），能少一个 Python 类的学习成本。
+
+---
+
+## 4. CMakeDeps 与 CMakeToolchain 两个 generator
+
+vcpkg 用一份 `vcpkg.cmake` 同时干"toolchain 注入"和"find_package 路径"两件事。Conan
+拆成两个 generator，关注点分离更清晰。
+
+### CMakeToolchain → `conan_toolchain.cmake`
+
+`conan install` 会按 profile 生成一份 `conan_toolchain.cmake`，内容大致：
+
+```cmake
+# 生成的，不是手写
+set(CMAKE_C_COMPILER "/usr/bin/gcc-13" CACHE FILEPATH "")
+set(CMAKE_CXX_COMPILER "/usr/bin/g++-13" CACHE FILEPATH "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+set(CMAKE_CXX_STANDARD 23)
+# 把 Conan 的 install 目录加进 CMAKE_PREFIX_PATH
+list(PREPEND CMAKE_PREFIX_PATH "/path/to/build/Release/generators")
+# ...
+```
+
+它的作用：**把 profile 里 `[settings]` 翻译成 CMake 的对应变量**，再把 Conan 安装的
+依赖目录注册到 `CMAKE_PREFIX_PATH`。
+
+通过 preset 的 `CMAKE_TOOLCHAIN_FILE` 指向它（详见
+[cmake-presets-guide.md §8](cmake-presets-guide.md#8-toolchain-hook-机制)）：
+
+```json
+"CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build/${presetName}/conan_toolchain.cmake"
+```
+
+### CMakeDeps → `<pkg>-config.cmake`
+
+每个 require 包会生成一个 `<pkg>-config.cmake` 文件，让 `find_package(<Pkg> CONFIG)`
+能找到。例如 gtest 会生成：
+
+```
+build/<preset>/generators/
+  GTestConfig.cmake
+  GTestConfigVersion.cmake
+  GTestTargets.cmake
+  GTestTargets-release.cmake
+```
+
+`find_package(GTest CONFIG)` 看到这些文件，就能创建 `GTest::gtest` 等 imported target。
+
+本仓库 [`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake) 的查找逻辑：
+
+```cmake
+find_package(GTest CONFIG QUIET)
+if(NOT GTest_FOUND)
+    find_package(GTest MODULE QUIET)
+endif()
+```
+
+vcpkg 与 Conan 都生成 `CONFIG` 文件，**同一份 `find_package` 代码二者都能命中**，这正
+是双轨支持的基础。
+
+### 与 vcpkg 单 toolchain 的设计差异
+
+| | vcpkg | Conan |
+| --- | --- | --- |
+| 文件数 | 1（`vcpkg.cmake`） | 2+（`conan_toolchain.cmake` + 每个包一个 config） |
+| 职责 | toolchain + 依赖搜索 | toolchain（CMakeToolchain）+ 依赖搜索（CMakeDeps），两者拆开 |
+| 触发安装 | configure 时 | **必须先 `conan install` 命令** |
+| 修改时机 | 改 `vcpkg.json` 后下次 configure 即生效 | 改 `conanfile.txt` 后必须重跑 `conan install` |
+
+---
+
+## 5. cmake_layout 与 per-preset 输出目录
+
+### `cmake_layout` 的默认布局
+
+Conan 提供几个内置 layout 函数。`cmake_layout` 是最常见的：
+
+```
+build/
+  <build_type>/
+    generators/        ← CMakeDeps + CMakeToolchain 输出在这里
+      conan_toolchain.cmake
+      GTestConfig.cmake
+      ...
+```
+
+构建类型在路径里，所以同一项目多 build_type 不冲突。
+
+### 本仓库的覆盖：per-preset 输出目录
+
+`conan install` 默认会用 `cmake_layout` 的路径，但本仓库希望每个 preset 一个目录，所以
+**用命令行覆盖输出目录**：
+
+```bash
+conan install . --output-folder=build/gcc-debug-conan --build=missing
+```
+
+`--output-folder` 让 Conan 把 generators 写到 `build/gcc-debug-conan/`，与
+preset 的 `binaryDir` 目录对齐。
+
+然后 preset 把 toolchain 路径写死成：
+
+```json
+"CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build/${presetName}/conan_toolchain.cmake"
+```
+
+`${presetName}` 会展开成 `gcc-debug-conan`，正好命中 `conan install` 的输出目录。
+
+### 为什么 `_conan` preset 的 toolchain 路径写死
+
+```json
+{
+    "name": "_conan",
+    "hidden": true,
+    "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build/${presetName}/conan_toolchain.cmake"
+    }
+}
+```
+
+写死带来一个**强制约定**：用户必须先跑 `conan install . --output-folder=build/<presetName>`
+才能跑 `cmake --preset <preset>`。文件不存在 cmake 报错很直白：
+
+```
+CMake Error: Could not find toolchain file:
+.../build/gcc-debug-conan/conan_toolchain.cmake
+```
+
+错误信息里直接告诉你少了 `conan install` 这一步。这比 vcpkg 的"configure 慢慢卡住装包"
+更显式。
+
+详细机制见 [cmake-presets-guide.md §8 toolchain hook 机制](cmake-presets-guide.md#8-toolchain-hook-机制)。
+
+---
+
+## 6. 本仓库工作流
+
+Conan 的核心工作流是**三步走**：
+
+```
+┌──────────────────────────────────┐
+│ ① conan install                  │  ← 按 profile 生成 toolchain + 装依赖
+│   --output-folder=build/<preset> │
+│   --build=missing                │
+└────────────┬─────────────────────┘
+             │ 产物：conan_toolchain.cmake / GTestConfig.cmake
+             ▼
+┌──────────────────────────────────┐
+│ ② cmake --preset <preset>        │  ← preset 读上一步生成的 toolchain
+└────────────┬─────────────────────┘
+             │ 产物：CMakeCache.txt / build.ninja / *.sln
+             ▼
+┌──────────────────────────────────┐
+│ ③ cmake --build --preset         │  ← 编译
+│   ctest --preset                 │  ← 测试
+└──────────────────────────────────┘
+```
+
+### 完整命令示例（GCC Debug）
+
+```bash
+# 第一步：让 Conan 装依赖到 build/gcc-debug-conan/
+conan install . \
+    --output-folder=build/gcc-debug-conan \
+    --build=missing \
+    -s build_type=Debug \
+    -s compiler.cppstd=23
+
+# 第二步：cmake 用上一步生成的 toolchain
+cmake --preset gcc-debug-conan
+
+# 第三步：构建 + 测试
+cmake --build --preset gcc-debug-conan
+ctest --preset gcc-debug-conan
+```
+
+### 关键参数
+
+#### `--build=missing`
+
+Conan 默认只用远端 prebuilt 二进制。如果远端没有当前 profile 对应的二进制（例如你的
+`compiler.version=13` 但远端只有 12 的），会失败。`--build=missing` 表示"远端没就本地
+build"，是日常开发的安全默认。
+
+#### `-s build_type=Debug`
+
+覆盖 profile 里的 `build_type`。本仓库需要这一行，因为 profile 默认 Release。
+
+#### `-s compiler.cppstd=23`
+
+覆盖 C++ 标准。本仓库要 C++23，profile 默认可能是 17。
+
+### 为什么 vcpkg 一步、Conan 必须两步
+
+| 阶段 | vcpkg | Conan |
+| --- | --- | --- |
+| 决定要装啥 | `vcpkg.json` | `conanfile.txt` + profile + 命令行 settings |
+| 触发安装 | CMake configure 时 toolchain 自动跑 | **`conan install` 命令显式跑** |
+| 安装完产物 | `vcpkg_installed/` | `build/<preset>/conan_toolchain.cmake` + `generators/` |
+| CMake 使用 | toolchain 注册路径 | toolchain 注册路径 + Deps 文件被 `find_package` 命中 |
+
+vcpkg 把"装包"塞进 toolchain 的 side effect；Conan 把它独立成命令。Conan 的方式让"装
+依赖"与"配置 CMake"两个动作显式分离，便于排查。
+
+### per-build-type 还是 per-preset 输出目录的权衡
+
+Conan 默认布局是 `build/<build_type>/`，本仓库覆盖成 `build/<presetName>/`。原因：
+
+- 默认布局：Debug / Release 各一份，不区分编译器；切编译器要小心
+- per-preset：每个 preset 完全隔离，gcc-debug 和 clang-debug 互不影响
+
+代价：每个 preset 都要单独 `conan install`（无法复用），但 Conan 有 cache，重复装不会
+真的重新编译。
+
+---
+
+## 7. 编译器矩阵下的 preset 设计
+
+仓库 `_gcc-conan` / `_clang-conan` 与 vcpkg 版的 `_gcc` / `_clang` 一一对应，区别只有
+toolchain：
+
+```json
+{
+    "name": "_gcc-conan",
+    "hidden": true,
+    "inherits": ["_conan", "_base"],
+    "generator": "Ninja",
+    "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+    },
+    "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+    }
+}
+```
+
+继承链与 vcpkg 完全镜像（详见
+[cmake-presets-guide.md §4 本仓库 preset 全景图](cmake-presets-guide.md#4-本仓库-preset-全景图)）：
+
+```
+_base + _conan → _gcc-conan → gcc-debug-conan
+                              gcc-release-conan
+                              gcc-relwithdebinfo-conan
+```
+
+### 为什么 `*-conan` preset 不固化 triplet
+
+Conan **完全不读** `VCPKG_TARGET_TRIPLET`。Conan 用 `[settings]` 表达 ABI，从 profile
+里读，与 cmake cache 变量无关。所以 conan preset 即使写了 triplet 也没用，**本仓库
+干脆不写**。
+
+### MinGW 在 Conan 下的处理
+
+vcpkg 下 MinGW 用户必须用 UserPresets 覆盖 triplet（详见
+[vcpkg-guide.md §6](vcpkg-guide.md#6-mingw-专题)）。Conan 下 MinGW 不需要 UserPresets
+叠层 —— 用对应的 profile 即可：
+
+```bash
+# 一个针对 MinGW 的 profile（保存为 ~/.conan2/profiles/mingw-ucrt64）
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu23
+compiler.libcxx=libstdc++11
+compiler.version=13
+os=Windows
+```
+
+```bash
+conan install . -pr=mingw-ucrt64 --output-folder=build/gcc-debug-conan --build=missing
+```
+
+`-pr=` 指定 profile，覆盖默认。剩下 cmake 步骤照旧。
+
+### MSVC + Conan 的多配置
+
+`msvc-conan` preset 是多配置（VS generator）：
+
+```json
+{
+    "name": "msvc-conan",
+    "displayName": "MSVC (VS 2022, Conan)",
+    "inherits": ["_conan", "_base"],
+    "generator": "Visual Studio 17 2022",
+    "architecture": { "value": "x64", "strategy": "set" }
+}
+```
+
+buildPreset 用 `configuration` 选构建类型：
+
+```json
+{ "name": "msvc-debug-conan",   "configurePreset": "msvc-conan", "configuration": "Debug" },
+{ "name": "msvc-release-conan", "configurePreset": "msvc-conan", "configuration": "Release" }
+```
+
+但 Conan 的 toolchain 是 per-build-type 的（一个 profile 设了一个 build_type）。本仓库
+给每个 build_type 各跑一次 `conan install --output-folder=build/msvc-conan/...` 才行。
+这是 Conan + 多配置生成器的固有摩擦点，详见
+[cmake-presets-guide.md §6 多配置 vs 单配置生成器](cmake-presets-guide.md#6-多配置-vs-单配置生成器)。
+
+---
+
+## 8. profile 进阶
+
+### host profile vs build profile
+
+交叉编译场景（在 x64 Linux 上构建 ARM Linux 二进制）：
+
+```bash
+conan install . \
+    --profile:host=arm-linux \    # 目标 ABI
+    --profile:build=default \     # 构建机 ABI（用于 build-tool 包，如 cmake/ninja）
+    --output-folder=build/arm-linux \
+    --build=missing
+```
+
+- `--profile:host`：目标平台 profile
+- `--profile:build`：构建机平台 profile（默认与 host 一致，非交叉时不用写）
+
+vcpkg 用 host triplet + build triplet 表达类似概念，但 Conan 的 profile 比 triplet 表达
+力更强。
+
+### profile 模板与 include
+
+profile 可以 include 其他 profile：
+
+```ini
+include(common-cpp23)
+
+[settings]
+build_type=Debug
+```
+
+`common-cpp23` 在同一 profile 目录下另一个文件，定义共享 settings。便于"基础 profile +
+变体"模式。
+
+### 命令行覆盖
+
+任何 profile 字段都能在命令行临时覆盖：
+
+```bash
+conan install . \
+    -s build_type=Debug \
+    -s compiler.version=14 \
+    -o boost*:shared=True \
+    -c tools.cmake.cmaketoolchain:generator=Ninja
+```
+
+- `-s`：覆盖 settings
+- `-o`：覆盖 options（包级开关）
+- `-c`：覆盖 conf（Conan 行为配置）
+
+适合"基础 profile + 偶尔需要的变种"场景，不用为每个变种建 profile 文件。
+
+---
+
+## 9. 与 CI 的集成（前瞻）
+
+### 当前状态
+
+本仓库 CI（[.github/workflows/ci.yml](../.github/workflows/ci.yml)）**只跑 vcpkg
+preset，未集成 Conan**。Conan preset 仅本地可用。
+
+### 为什么 CI 没集成 Conan
+
+- **避免双倍 matrix**：当前已有 `linux-gcc` / `linux-clang` / `windows-msvc` 三个 build
+  job，加 Conan 等于 ×2 = 6 个 job，CI 时间和 GHA 配额翻倍
+- **vcpkg 已能验证依赖管理是工作的**：Conan 与 vcpkg 都走 `find_package(GTest CONFIG)`，
+  vcpkg 跑通基本能保证 Conan 也跑通
+- **教学项目优先级**：维护 vcpkg + Conan 双 CI 不如把精力放在多模块覆盖上
+
+### 如果未来要加
+
+设计草图（不是已实现，仅供参考）：
+
+```yaml
+- name: Install Conan
+  run: pip install conan && conan profile detect
+
+- name: Conan install
+  run: |
+    conan install . \
+      --output-folder=build/${{ matrix.preset }}-conan \
+      --build=missing \
+      -s build_type=RelWithDebInfo \
+      -s compiler.cppstd=23
+
+- name: CMake configure (Conan)
+  run: cmake --preset ${{ matrix.preset }}-conan
+
+- name: Build (Conan)
+  run: cmake --build --preset ${{ matrix.preset }}-conan
+
+- name: Test (Conan)
+  run: ctest --preset ${{ matrix.preset }}-conan
+```
+
+需要解决的问题：
+
+- **Conan cache**：`~/.conan2/p/` 应该走 GHA cache（`actions/cache@v4`）
+- **profile 一致性**：CI 的 `conan profile detect` 默认 cppstd 可能跟本地不同，需要
+  `-s` 覆盖统一
+- **matrix 扩展**：是新增 `*-conan` job 还是用 step 在同一 job 里跑两遍
+
+详见 [ci-guide.md §11 扩展功能](ci-guide.md#11-扩展功能)。
+
+---
+
+## 10. 常见问题与排查
+
+### "Could not find toolchain file: conan_toolchain.cmake"
+
+99% 是忘了第一步 `conan install`。本仓库 `_conan` preset 把 toolchain 路径写死，文件
+不存在 cmake 直接报错。修法：
+
+```bash
+conan install . --output-folder=build/<presetName> --build=missing
+cmake --preset <presetName>
+```
+
+剩下 1% 是 `--output-folder` 跟 preset 名拼错。preset 名是 `gcc-debug-conan`，
+output-folder 必须也是 `build/gcc-debug-conan`，不是 `build/gcc-debug`。
+
+### profile 与编译器版本不匹配
+
+```
+ERROR: Missing prebuilt package for 'gtest/1.15.0'
+... compiler.version=14 ...
+You can try:
+    'conan install ... --build=missing'
+```
+
+远端 binary repo 没有当前 profile 对应的二进制。两个方向：
+
+- 加 `--build=missing` 让 Conan 本地 build（最常见）
+- 改 profile 的 `compiler.version` 与远端有的对齐（节省 build 时间）
+
+### libcxx ABI 链接错乱（GCC 5+ 的双 ABI）
+
+GCC 5 引入了 dual ABI，老代码用 `libstdc++`（_GLIBCXX_USE_CXX11_ABI=0），新代码用
+`libstdc++11`（_GLIBCXX_USE_CXX11_ABI=1）。混用会出现 `std::string` / `std::list` 这
+些类型链接错乱：
+
+```
+undefined reference to `f(std::__cxx11::basic_string<...>)'
+```
+
+修法：profile 里 `compiler.libcxx=libstdc++11`（现代默认），并保证项目不显式 `-D_GLIBCXX_USE_CXX11_ABI=0`。
+
+### MSVC `compiler.runtime` 与 `gtest_force_shared_crt`
+
+vcpkg 用 `triplet` 决定 CRT，Conan 用 `compiler.runtime` 字段：
+
+```ini
+[settings]
+compiler=msvc
+compiler.runtime=dynamic       # /MD
+compiler.runtime_type=Release  # /MD vs /MDd
+```
+
+本仓库 [`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake) 强制
+`gtest_force_shared_crt: ON`，配合 `compiler.runtime=dynamic`（默认）就对齐了。如果
+profile 改成 `runtime=static`，记得同步把 `gtest_force_shared_crt` 改 OFF 并设
+`CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`。
+
+详见 [vcpkg-guide.md §8 MSVC CRT 对齐](vcpkg-guide.md#8-msvc-crt-对齐)。
+
+### Conan cache 占空间太大
+
+`~/.conan2/p/`（packages cache）可能涨到几十 GB。清理：
+
+```bash
+# 清理 90 天没用的包
+conan cache clean --temp --download --source --build "*"
+
+# 完全重置（核选项）
+rm -rf ~/.conan2/p/
+```
+
+cache 删了下次 install 会重新下载/编译。
+
+### 修改 conanfile.txt 后没生效
+
+记住 Conan 是**两步走**：改 `conanfile.txt` 必须**重跑** `conan install`，光跑
+`cmake --preset` 没用 —— preset 读的是上次 install 生成的旧 toolchain 文件。
+
+### `--build=missing` 总是 build 同一个包
+
+通常意味着你的 profile 在多次 install 间发生了细微变化（package_id 一直变，cache 命中
+不了）。检查：
+
+- `conan profile show` 是否每次都一样
+- 是否有命令行 `-s` / `-o` 不一致
+- cppstd 是否被某些工具偷偷改过
+
+确认 profile 稳定后，`--build=missing` 第一次会 build，第二次起命中 cache，秒过。

--- a/docs/vcpkg-guide.md
+++ b/docs/vcpkg-guide.md
@@ -1,0 +1,626 @@
+# vcpkg 使用与配置完整指南
+
+> 本文档系统讲解 vcpkg 的工作原理、安装与首次配置、manifest 模式、triplet 与 ABI、
+> Windows MinGW 专题、binary cache 加速，以及本仓库 `vcpkg.json` 是如何与 CMake Presets
+> 衔接的。
+>
+> 配套文件：[`vcpkg.json`](../vcpkg.json) / [`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake)
+>
+> 配套阅读：
+> - [`docs/cmake-presets-guide.md`](cmake-presets-guide.md) —— preset 与 toolchain hook 机制
+> - [`docs/conan-guide.md`](conan-guide.md) —— 平行的另一种方案
+> - [`docs/ci-guide.md`](ci-guide.md) —— CI 中 vcpkg binary cache 配置
+
+---
+
+## 目录
+
+1. [什么是 vcpkg，它解决什么问题](#1-什么是-vcpkg它解决什么问题)
+2. [安装与首次配置](#2-安装与首次配置)
+3. [manifest 模式与 vcpkg.json 详解](#3-manifest-模式与-vcpkgjson-详解)
+4. [toolchain 文件的工作机制](#4-toolchain-文件的工作机制)
+5. [triplet：ABI 的命名空间](#5-tripletabi-的命名空间)
+6. [MinGW 专题](#6-mingw-专题)
+7. [binary cache：加速重复构建](#7-binary-cache加速重复构建)
+8. [MSVC CRT 对齐](#8-msvc-crt-对齐)
+9. [常用命令速查](#9-常用命令速查)
+10. [常见问题与排查](#10-常见问题与排查)
+
+---
+
+## 1. 什么是 vcpkg，它解决什么问题
+
+**vcpkg** 是微软开源的 C++ 包管理器：用一份清单文件（`vcpkg.json`）声明依赖，vcpkg
+负责下载、编译、按 ABI 配置安装到本地，并通过 CMake 的 toolchain 文件让你的项目
+`find_package` 能找到。
+
+### C++ 没有 npm/pip 的痛点
+
+Python 装个 `requests` 是 `pip install requests`，不用关心：
+
+- 编译？不用，纯 Python
+- ABI？不用，只有一个 CPython
+- 链接？不用，import 即可
+
+C++ 装一个 GoogleTest 要回答一连串问题：
+
+- 用什么编译器？（GCC / Clang / MSVC，版本？）
+- 静态还是动态？
+- 链接 MSVC 的哪个 CRT？（/MD / /MT）
+- 装到哪？怎么让 `find_package(GTest)` 找到？
+
+vcpkg 把这些问题打包成一个概念叫 **triplet**（详见 [§5](#5-tripletabi-的命名空间)），
+让你只需要声明依赖名，vcpkg 替你把 ABI 拼对。
+
+### vcpkg 的两种工作模式
+
+| 模式 | 入口 | 安装位置 | 适用 |
+| --- | --- | --- | --- |
+| **classic** | `vcpkg install gtest` | `<vcpkg-root>/installed/` 全局共享 | 个人随手玩 |
+| **manifest** | `vcpkg.json` + CMake | per-project 的 `vcpkg_installed/` | 团队/CI/可复现 |
+
+**本仓库用 manifest 模式**：每个项目一份 `vcpkg.json`，依赖随源码一起进版本管理，谁
+clone 都装得出一样的版本。下文专讲 manifest 模式。
+
+### 与 Conan 的高层对比
+
+完整对比表见 [conan-guide.md §1](conan-guide.md#1-什么是-conan它解决什么问题)。一句话：
+**vcpkg 像 apt（编译型）；Conan 像 maven（recipe + 二进制分发）**。本仓库同时支持两种，
+让用户体验不同生态。
+
+---
+
+## 2. 安装与首次配置
+
+vcpkg 的官方推荐安装方式是 **git clone 源码树**，不是包管理器（包管理器版本只装可执行
+文件，不含 `scripts/ports/triplets`，无法走 manifest 模式）。
+
+### Linux / macOS
+
+```bash
+# 1) 克隆 vcpkg
+git clone https://github.com/microsoft/vcpkg ~/vcpkg
+~/vcpkg/bootstrap-vcpkg.sh
+
+# 2) 设置 VCPKG_ROOT 环境变量（一次性）
+echo 'export VCPKG_ROOT=$HOME/vcpkg' >> ~/.bashrc   # 或 ~/.zshrc
+source ~/.bashrc
+```
+
+> **macOS 注意**：不要 `brew install vcpkg` —— Homebrew 的 formula 只装 vcpkg 可执行
+> 文件，不含完整源码树。后续 `cmake --preset` 会因为找不到
+> `$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake` 而失败。
+
+### Windows
+
+```powershell
+# 1) 克隆 vcpkg（建议放短路径，避免 MAX_PATH 问题）
+git clone https://github.com/microsoft/vcpkg D:\vcpkg
+D:\vcpkg\bootstrap-vcpkg.bat
+
+# 2) 持久化 VCPKG_ROOT 到用户级环境变量
+setx VCPKG_ROOT "D:\vcpkg"
+# 注意：setx 设置的环境变量在新开的 shell 才生效，当前 shell 仍未生效
+```
+
+### 为什么本仓库用 `$env{VCPKG_ROOT}` 而不是固定路径
+
+```json
+"CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+```
+
+把路径写成环境变量展开有几个好处：
+
+- **机器无关**：每个开发者把 vcpkg 装在自己喜欢的位置
+- **多项目共享同一份 vcpkg root**：vcpkg 的 binary cache 能跨项目复用
+- **CI 与本地一致**：CI 也只是设 `VCPKG_ROOT` 环境变量，preset 不需要改
+
+代价：用户必须先设环境变量。第一次 configure 报错 "Could not find toolchain file" 时，
+99% 是 `VCPKG_ROOT` 没设或没在当前 shell 里生效。
+
+---
+
+## 3. manifest 模式与 vcpkg.json 详解
+
+本仓库的 `vcpkg.json` 全文：
+
+```json
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "name": "moderncpp",
+    "version-string": "0.1.0",
+    "description": "Modern C++ learning modules",
+    "dependencies": [
+        "gtest"
+    ]
+}
+```
+
+### 字段解释
+
+| 字段 | 必需 | 含义 |
+| --- | --- | --- |
+| `$schema` | 否 | JSON Schema URL，让 IDE 能补全/校验 |
+| `name` | 是 | 项目名（小写、可含 `-`），vcpkg 内部唯一标识 |
+| `version-string` | 否（建议有） | 项目版本，对 vcpkg 决策无影响，仅元数据 |
+| `description` | 否 | 一行描述 |
+| `dependencies` | 是 | 依赖列表，可以是字符串或对象 |
+
+### dependencies 的两种写法
+
+**简单字符串**（本仓库用法）：
+
+```json
+"dependencies": [ "gtest" ]
+```
+
+vcpkg 装最新 baseline 版本。
+
+**对象写法**（带 features / 平台限定）：
+
+```json
+"dependencies": [
+    {
+        "name": "boost-asio",
+        "features": ["ssl"],
+        "platform": "!windows"
+    },
+    {
+        "name": "fmt",
+        "version>=": "10.0.0"
+    }
+]
+```
+
+字段：
+
+- `features`：启用包的可选特性
+- `platform`：仅在某平台安装（vcpkg 自己的平台表达式语法）
+- `version>=`：最低版本约束（需要配合 baseline，详见下节）
+
+### 锁文件：baseline 与 vcpkg-configuration.json
+
+vcpkg 默认按 vcpkg root 当前 commit 决定包版本（commit 即 baseline）。如果想锁版本：
+
+```json
+{
+    "name": "moderncpp",
+    "dependencies": [ "gtest" ],
+    "builtin-baseline": "5ee5eee0d3e9c6098b24d263e9099edcdcef6631"
+}
+```
+
+或单独建 `vcpkg-configuration.json` 指定 registry baseline。
+
+**本仓库未启用 baseline**，原因：教学项目用最新版有助于体验新特性；CI 通过
+[`lukka/run-vcpkg@v11`](../.github/workflows/ci.yml#L86) 的 `vcpkgGitCommitId` 已经固定
+vcpkg 版本，等效于 baseline。
+
+### 与 classic 模式的差异
+
+```bash
+# classic 模式：手动安装到 vcpkg root（全局共享）
+vcpkg install gtest
+
+# manifest 模式：cmake configure 时自动按 vcpkg.json 装到本项目 build 目录
+cmake --preset gcc-debug
+# vcpkg 自动安装到 build/gcc-debug/vcpkg_installed/x64-linux/
+```
+
+manifest 模式的优势：
+
+- 依赖随源码进版本管理（`vcpkg.json` 提交，`vcpkg_installed/` 不提交）
+- 不同项目装不同版本不互相污染
+- CI 与本地装的就是 `vcpkg.json` 声明的版本
+
+---
+
+## 4. toolchain 文件的工作机制
+
+vcpkg 通过 CMake 的 `CMAKE_TOOLCHAIN_FILE` 钩子接入项目。机制详见
+[cmake-presets-guide.md §8 toolchain hook 机制](cmake-presets-guide.md#8-toolchain-hook-机制)。
+本节聚焦 vcpkg 的具体行为。
+
+### `vcpkg.cmake` 在 configure 时干什么
+
+依次执行：
+
+1. **检测模式**：当前目录是否有 `vcpkg.json` → manifest 模式
+2. **决定 triplet**：从 `VCPKG_TARGET_TRIPLET` cache 变量、`VCPKG_DEFAULT_TRIPLET`
+   环境变量、主机自动检测三处依次取（详见 [§5](#5-tripletabi-的命名空间)）
+3. **解析 vcpkg.json**：列出所有 dependencies
+4. **安装缺失依赖**：调用 `vcpkg install`，输出装到
+   `<binaryDir>/vcpkg_installed/<triplet>/`
+5. **注入 find_package 路径**：把上述目录加进 `CMAKE_PREFIX_PATH`，让后续
+   `find_package(GTest CONFIG)` 能找到
+
+第 4 步是首次 configure 慢的原因 —— 第一次跑 `cmake --preset gcc-debug` 可能等几分钟，
+就是 vcpkg 在编译 gtest。第二次起，binary 已经在 `vcpkg_installed/` 里，秒过。
+
+### `find_package(GTest CONFIG)` 是怎么命中的
+
+本仓库 [`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake)：
+
+```cmake
+find_package(GTest CONFIG QUIET)
+if(NOT GTest_FOUND)
+    find_package(GTest MODULE QUIET)
+endif()
+```
+
+- `CONFIG` 模式查找 `<triplet>/share/gtest/GTestConfig.cmake` —— vcpkg 装的包附带这个
+- `MODULE` 模式找 `FindGTest.cmake` —— 系统包管理器装的 gtest 走这个
+- 两个都找不到，FATAL_ERROR 提示用户装 vcpkg 或 Conan
+
+vcpkg 装的 gtest 走 `CONFIG` 路径，靠 toolchain 文件把
+`build/<preset>/vcpkg_installed/<triplet>/share/gtest/` 加进 `CMAKE_PREFIX_PATH` 来命中。
+
+---
+
+## 5. triplet：ABI 的命名空间
+
+### 什么是 triplet
+
+triplet 是 vcpkg 用一个字符串描述的"目标 ABI"。命名通常是
+`<架构>-<平台>[-<链接方式>][-<CRT>]`：
+
+| triplet | 架构 | 平台 | 链接 | CRT |
+| --- | --- | --- | --- | --- |
+| `x64-linux` | x86_64 | Linux (glibc) | dynamic | — |
+| `arm64-linux` | aarch64 | Linux | dynamic | — |
+| `x64-osx` | x86_64 | macOS | dynamic | — |
+| `arm64-osx` | aarch64 | macOS (Apple Silicon) | dynamic | — |
+| `x64-windows` | x86_64 | Windows MSVC | dynamic | /MD（动态 CRT） |
+| `x64-windows-static` | x86_64 | Windows MSVC | static | /MT（静态 CRT） |
+| `x64-mingw-dynamic` | x86_64 | Windows MinGW | dynamic | UCRT |
+| `x64-mingw-static` | x86_64 | Windows MinGW | static | UCRT |
+
+triplet 决定了 vcpkg 装出来的二进制是什么样的。**triplet 与你将要链接它的代码必须 ABI
+一致**，否则一堆 `undefined reference` 或链接错乱。
+
+### 本仓库的 triplet 策略（PR #5 后）
+
+| 主机 | preset | VCPKG_TARGET_TRIPLET 来源 |
+| --- | --- | --- |
+| Linux x64 / ARM64 | `gcc-*` / `clang-*` | **vcpkg 主机自动检测** |
+| macOS Intel / Apple Silicon | `clang-*` | **vcpkg 主机自动检测** |
+| Windows MSVC | `msvc` | preset 固化为 `x64-windows` |
+| Windows clang-cl | `clang-cl-*` | preset 固化为 `x64-windows` |
+| Windows MinGW | `my-gcc-*`（用户叠层） | UserPresets 覆盖为 `x64-mingw-dynamic` |
+
+### 为什么 Linux/macOS 不固化 triplet
+
+每个 OS 上只有一种主流 ABI：
+
+- Linux：glibc + libstdc++（对应 `x64-linux` / `arm64-linux`）
+- macOS：libc++（对应 `x64-osx` / `arm64-osx`）
+
+vcpkg 看主机 OS + `CMAKE_HOST_SYSTEM_PROCESSOR` 就能正确决定。**硬编码反而会让 ARM64
+Linux、Apple Silicon 等用户拿到错的二进制**。
+
+历史上仓库曾经在 `_gcc` / `_clang` 上硬编码 `x64-linux`（PR #3），后被代码评审指出
+退化了主机自动检测，PR #5 改回让 vcpkg 自己决定。
+
+### 为什么 Windows 必须固化
+
+Windows 上 ABI 不唯一：MSVC ABI 和 MinGW ABI 共存。vcpkg 默认猜 `x64-windows`（MSVC
+ABI），对 MSVC / clang-cl 用户是对的，对 MinGW 用户是错的。**preset 固化是为了对
+"想用 MSVC ABI" 的场景明确表态，MinGW 用户走 UserPresets 覆盖**（详见 [§6](#6-mingw-专题)）。
+
+### 自定义 triplet
+
+vcpkg 允许在仓库里放自定义 triplet（`.cmake` 文件），通过
+`VCPKG_OVERLAY_TRIPLETS` 启用。本仓库未使用此机制 —— 内置 triplet 已经够。
+
+---
+
+## 6. MinGW 专题
+
+### 问题陈述
+
+MinGW（msys2 ucrt64 / mingw64 环境）在 Windows 上提供 GNU 工具链：
+
+- 用 GNU 的 name mangling 与 ABI
+- 链接 libstdc++（不是 MSVC 的 STL）
+- 异常处理走 SEH/Dwarf（MinGW 实现，不是 MSVC 的）
+
+而 vcpkg 在 Windows 上默认用 `x64-windows` triplet，装出 **MSVC ABI + MSVC STL** 的
+二进制。把这种 gtest 拿去给 MinGW g++ 链接：
+
+```
+undefined reference to `testing::AssertionResult::AssertionResult(...)'
+undefined reference to `testing::Test::SetUp()'
+... (一长串)
+```
+
+符号 mangling 完全对不上、STL 类型布局不一样。链接必然失败。
+
+### 为什么 vcpkg 不"看编译器再决定 triplet"
+
+vcpkg 的 triplet 决策发生在 **CMake 知道编译器之前**：你跑 `cmake --preset` 时，CMake
+先加载 toolchain 文件，vcpkg 这时只有环境变量和命令行参数能看，还没进到
+`project()` 检测编译器那一步。所以它只能按主机 OS 给个保守默认。
+
+### 解决方案：CMakeUserPresets.json 叠层
+
+仓库 `_gcc` / `_clang` 这些 preset 在 Windows 上被 condition 门控（详见
+[cmake-presets-guide.md §5](cmake-presets-guide.md#5-condition让-preset-跨平台共存)），
+直接用不了。MinGW 用户在仓库根建一份 **`CMakeUserPresets.json`**（已 .gitignored），
+叠一层带 triplet 覆盖 + `condition: null` 的 leaf preset：
+
+```json
+{
+    "version": 6,
+    "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
+
+    "configurePresets": [
+        {
+            "name": "_mingw-triplet",
+            "hidden": true,
+            "cacheVariables": { "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic" }
+        },
+
+        { "name": "my-gcc-debug",            "inherits": ["_mingw-triplet", "gcc-debug"],          "condition": null },
+        { "name": "my-gcc-release",          "inherits": ["_mingw-triplet", "gcc-release"],        "condition": null },
+        { "name": "my-gcc-relwithdebinfo",   "inherits": ["_mingw-triplet", "gcc-relwithdebinfo"], "condition": null },
+        { "name": "my-gcc-minsizerel",       "inherits": ["_mingw-triplet", "gcc-minsizerel"],     "condition": null },
+
+        { "name": "my-clang-debug",          "inherits": ["_mingw-triplet", "clang-debug"],          "condition": null },
+        { "name": "my-clang-release",        "inherits": ["_mingw-triplet", "clang-release"],        "condition": null },
+        { "name": "my-clang-relwithdebinfo", "inherits": ["_mingw-triplet", "clang-relwithdebinfo"], "condition": null },
+        { "name": "my-clang-minsizerel",     "inherits": ["_mingw-triplet", "clang-minsizerel"],     "condition": null }
+    ],
+
+    "buildPresets": [
+        { "name": "my-gcc-debug",            "configurePreset": "my-gcc-debug" },
+        { "name": "my-gcc-release",          "configurePreset": "my-gcc-release" },
+        { "name": "my-gcc-relwithdebinfo",   "configurePreset": "my-gcc-relwithdebinfo" },
+        { "name": "my-gcc-minsizerel",       "configurePreset": "my-gcc-minsizerel" },
+
+        { "name": "my-clang-debug",          "configurePreset": "my-clang-debug" },
+        { "name": "my-clang-release",        "configurePreset": "my-clang-release" },
+        { "name": "my-clang-relwithdebinfo", "configurePreset": "my-clang-relwithdebinfo" },
+        { "name": "my-clang-minsizerel",     "configurePreset": "my-clang-minsizerel" }
+    ],
+
+    "testPresets": [
+        { "name": "my-gcc-debug",            "configurePreset": "my-gcc-debug",            "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-gcc-release",          "configurePreset": "my-gcc-release",          "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-gcc-relwithdebinfo",   "configurePreset": "my-gcc-relwithdebinfo",   "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-gcc-minsizerel",       "configurePreset": "my-gcc-minsizerel",       "output": { "outputOnFailure": true, "shortProgress": true } },
+
+        { "name": "my-clang-debug",          "configurePreset": "my-clang-debug",          "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-clang-release",        "configurePreset": "my-clang-release",        "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-clang-relwithdebinfo", "configurePreset": "my-clang-relwithdebinfo", "output": { "outputOnFailure": true, "shortProgress": true } },
+        { "name": "my-clang-minsizerel",     "configurePreset": "my-clang-minsizerel",     "output": { "outputOnFailure": true, "shortProgress": true } }
+    ]
+}
+```
+
+### 三个关键点解释
+
+1. **`_mingw-triplet` hidden preset**：单独抽出来便于复用，避免每个 leaf 重复写
+   `VCPKG_TARGET_TRIPLET`
+2. **`inherits: ["_mingw-triplet", "gcc-debug"]` 顺序**：后者（`gcc-debug`）会覆盖前者
+   的 cacheVariables —— 但 `gcc-debug` 不设 triplet，所以 `_mingw-triplet` 的 triplet
+   留下；编译器、generator 等从 `gcc-debug` 链路继承
+3. **`"condition": null` 显式解除**：`gcc-debug` 链路上的 `_gcc` 有
+   `hostSystemName == Linux` 门控，叠层 leaf 必须显式声明 `condition: null` 才能在
+   Windows 上可见
+
+### 用法
+
+```bash
+# 用叠层 preset 替代仓库 preset
+cmake --preset my-gcc-debug
+cmake --build --preset my-gcc-debug
+ctest --preset my-gcc-debug
+```
+
+### 备选方案：configure 时手动 -D
+
+懒得建 UserPresets 也行，但每次都要敲：
+
+```bash
+cmake --preset gcc-debug -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic
+```
+
+注意：这种方式**绕不过 condition 门控**，`gcc-debug` 在 Windows 上根本不可见，命令会
+报 "No such preset"。所以 MinGW 用户实际上**只能走 UserPresets**。
+
+---
+
+## 7. binary cache：加速重复构建
+
+### 为什么 vcpkg 慢
+
+vcpkg 默认从源码编译。装一个 boost 可能要 20 分钟。CI 跑一次就要 20 分钟全用在 vcpkg
+上，本地切 preset 也是 20 分钟一次。
+
+**解决方案：binary cache** —— 把编译结果按 ABI hash 存起来，下次同 ABI 的依赖直接
+解压，秒过。
+
+### binary cache 的 hash 来源
+
+vcpkg 用以下因子计算 hash：
+
+- triplet
+- 包版本 + features
+- 编译器版本
+- vcpkg 自身版本（commit）
+- 关键工具链选项
+
+只要 hash 一致，就直接用 cache。
+
+### 几种 binary cache 后端
+
+| 后端 | 适用 |
+| --- | --- |
+| **本地目录** | 单机多项目共享（默认在 `~/.cache/vcpkg/archives/`） |
+| **NuGet** | 团队内网共享（含 GitHub Packages、Azure Artifacts） |
+| **`x-gha`** | GitHub Actions 内置 cache |
+| **HTTP** | 自建 HTTP server |
+
+### 本仓库 CI 的配置
+
+```yaml
+env:
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+```
+
+字段含义：
+
+- `clear`：清空默认源（避免回退到本地 cache 浪费时间）
+- `x-gha,readwrite`：用 GitHub Actions cache，可读可写
+
+每个 job 跑完会把新 cache 写入 GHA cache，后续 PR 命中就秒过。
+
+详细配置（GHA cache token 注入、与 `lukka/run-vcpkg@v11` 的衔接）见
+[ci-guide.md §6 缓存与加速](ci-guide.md#6-缓存与加速)。
+
+### 本地启用 binary cache
+
+```bash
+export VCPKG_BINARY_SOURCES="default,readwrite"
+```
+
+`default` 即本地目录后端，路径默认 `~/.cache/vcpkg/archives/`。多项目共享同一份缓存。
+
+---
+
+## 8. MSVC CRT 对齐
+
+### 问题
+
+MSVC 的 CRT（C 运行时）有两类：
+
+- **/MD**（动态 CRT，msvcrt.dll）：本仓库默认
+- **/MT**（静态 CRT，链进 .exe）
+
+**gtest 默认用静态 CRT**（`gtest_force_shared_crt: OFF`）。如果你的项目用动态 CRT 链
+gtest 的静态 CRT 版本，会报 LNK2038 错乱：
+
+```
+error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease'
+doesn't match value 'MD_DynamicRelease' in main.obj
+```
+
+### 本仓库的解决方案
+
+[`cmake/Dependencies.cmake`](../cmake/Dependencies.cmake)：
+
+```cmake
+if(MSVC)
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif()
+```
+
+强制 gtest 用动态 CRT，与本项目的 `/MD` 默认对齐。
+
+### 与 triplet 的关系
+
+不同 triplet 自带不同 CRT 默认：
+
+- `x64-windows`：`/MD`（动态 CRT，与本仓库默认一致）
+- `x64-windows-static`：`/MT`（静态 CRT，需要项目把 `CMAKE_MSVC_RUNTIME_LIBRARY` 改为
+  `MultiThreaded`）
+- `x64-windows-static-md`：`/MD` 但其他依赖静态 —— 中间方案
+
+本仓库选 `x64-windows`，所以 `gtest_force_shared_crt: ON` 是正确选择。如果哪天换
+`x64-windows-static`，要把这一行改为 `OFF` 并同步设 `CMAKE_MSVC_RUNTIME_LIBRARY`。
+
+### Conan 下的等价问题
+
+Conan 用 `compiler.runtime` 字段表达同样的概念。详见
+[conan-guide.md §10](conan-guide.md#10-常见问题与排查)。
+
+---
+
+## 9. 常用命令速查
+
+### manifest 模式（本仓库工作流）
+
+```bash
+# configure 时 vcpkg 自动安装依赖
+cmake --preset gcc-debug
+
+# 强制重新解析 vcpkg.json（修改了依赖列表后）
+cmake --preset gcc-debug --fresh
+
+# 看 vcpkg 装到了哪
+ls build/gcc-debug/vcpkg_installed/x64-linux/share/
+```
+
+### 直接调用 vcpkg
+
+```bash
+# 看仓库依赖树
+cd build/gcc-debug && ../../../$VCPKG_ROOT/vcpkg list
+
+# 搜索某个包
+$VCPKG_ROOT/vcpkg search fmt
+
+# 升级 vcpkg 自身（影响包版本）
+cd $VCPKG_ROOT && git pull && ./bootstrap-vcpkg.sh
+```
+
+### 排查时的 verbose 选项
+
+```bash
+# vcpkg 操作的详细日志
+cmake --preset gcc-debug -DVCPKG_INSTALL_OPTIONS="--debug"
+
+# vcpkg 装某个包失败时，build log 在
+ls build/gcc-debug/vcpkg-bootstrap.log
+ls $VCPKG_ROOT/buildtrees/<port-name>/
+```
+
+---
+
+## 10. 常见问题与排查
+
+### "Could not find toolchain file: vcpkg.cmake"
+
+原因：
+
+1. **`VCPKG_ROOT` 未设**：跑 `echo $VCPKG_ROOT`（Linux/Mac）或 `echo %VCPKG_ROOT%`
+   （Windows）确认
+2. **设了但未在当前 shell 生效**：Linux 要 `source ~/.bashrc`；Windows 的 `setx`
+   只对新开 shell 生效，重开终端
+3. **路径里有空格未 quote**：用环境变量持久化，避免 inline 路径
+
+### MinGW 链接失败：`undefined reference to testing::...`
+
+100% 是 triplet 不匹配 —— vcpkg 装的是 `x64-windows`（MSVC ABI），但你用 MinGW gcc
+链接。修法见 [§6 MinGW 专题](#6-mingw-专题)。
+
+### vcpkg 拉源码失败（HTTP 502 / git clone failed）
+
+GitHub 偶尔抖动。重新跑一次 `cmake --preset` 通常就好。CI 上可以用
+`gh run rerun --failed` 重试。如果反复失败，检查 `$VCPKG_ROOT/buildtrees/` 下的具体
+port log，看是不是某个 port 的上游源不稳定。
+
+### 切了 preset 后 vcpkg 重新装一遍
+
+不同 preset 的 `binaryDir` 不同，`vcpkg_installed/` 也不同。第一次切是会重装。开了
+binary cache（[§7](#7-binary-cache加速重复构建)）后，重装是从 cache 解压，秒过。
+
+### 升级 vcpkg 后版本意外变化
+
+vcpkg 的"包版本"由 vcpkg root 的 commit 决定。`git pull` 一下 vcpkg root，gtest 可能
+就从 1.15.0 跳到 1.16.0。要锁版本：
+
+- 设 `builtin-baseline` 在 `vcpkg.json` 里
+- 或 CI 用 `lukka/run-vcpkg@v11` 的 `vcpkgGitCommitId` 锁 vcpkg commit
+
+### MSVC 链接 LNK2038（CRT 不匹配）
+
+详见 [§8 MSVC CRT 对齐](#8-msvc-crt-对齐)。本仓库 `gtest_force_shared_crt: ON` 已经
+解决，触发这个错通常是你换了 `x64-windows-static` triplet 但没同步改 CMake 的
+runtime library 设置。
+
+### `vcpkg_installed/` 占空间太大
+
+每个 preset 的 `build/<preset>/vcpkg_installed/` 都是一份完整的依赖。多 preset 切来切
+去会越攒越多。清理：删掉 `build/` 下不再用的 preset 目录即可，不影响 vcpkg root 与
+binary cache。


### PR DESCRIPTION
## Summary

`docs/` 此前 5 篇文档全部聚焦 clangd / clang-format / clang-tidy / CI，**没有 CMake Presets / vcpkg / Conan 的专题指南**。README 虽有 quickstart，但缺少：

- preset 分层继承（`_base` / `_vcpkg` / `_conan` / `_gcc`）的设计原理
- triplet / ABI / CRT 概念
- MinGW、binary cache、Conan profile 等实战专题
- 仓库实际踩过的坑的排查文档（PR #3/#5 triplet 策略变迁、MSVC CRT 对齐等）

本 PR 新增三篇 docs/，初学者向，与现有 `ci-guide.md` 风格一致。

## 三篇文档结构

### 1. `docs/cmake-presets-guide.md`（10 章，约 5000 字）

主轴文档。preset 设计原理、`hidden` + `inherits` 三层继承、本仓库 preset 全景图（**完整 JSON 唯一展示位置**）、`condition` 跨平台门控、多配置 vs 单配置、testPresets、**toolchain hook 机制**（vcpkg/conan guide 反向引用此处）、CMakeUserPresets.json、排查 FAQ。

### 2. `docs/vcpkg-guide.md`（10 章，约 4500 字）

vcpkg 概念与 manifest 模式、安装与 `VCPKG_ROOT`、`vcpkg.json` 详解（**全文唯一展示位置**）、toolchain 工作机制、triplet/ABI（含 PR #5 后的 host-detection 策略）、**MinGW 专题**（UserPresets 完整模板唯一展示位置）、binary cache、MSVC CRT 对齐、常用命令、排查 FAQ。

### 3. `docs/conan-guide.md`（10 章，约 4500 字）

Conan 2.x 概念（**含 vcpkg vs Conan 对比表**，vcpkg-guide 反向引用此处）、profile 初始化与 vcpkg triplet 对照、`conanfile.txt` 详解（**全文唯一展示位置**）、CMakeDeps + CMakeToolchain 拆分设计、cmake_layout per-preset 输出目录、三步走工作流、编译器矩阵下的 preset 设计、profile 进阶、CI 集成前瞻、排查 FAQ。

## 跨文档引用与归属仲裁

为避免重复，每个权威配置只在一处展示：

| 内容 | 唯一归属 |
| --- | --- |
| 完整 preset JSON 块 | cmake-presets-guide §4 |
| `vcpkg.json` 全文 | vcpkg-guide §3 |
| `conanfile.txt` 全文 | conan-guide §3 |
| MinGW UserPresets 完整模板 | vcpkg-guide §6 |
| `gtest_force_shared_crt` 解释 | vcpkg-guide §8 |
| vcpkg vs Conan 对比表 | conan-guide §1 |

## README 同步改动

- "依赖安装"段尾追加跳转链接到三篇 guide
- MinGW UserPresets 完整模板压缩为 5-6 行核心 + "完整模板与原理见 vcpkg-guide.md §6"
- triplet 速查表后加"为什么这样设计"反向链接

## Test plan

- [ ] CI: 四个 job (`linux-gcc` / `linux-clang` / `windows-msvc` / `lint`) 全 pass —— 纯文档改动应无影响
- [ ] 跨文档锚点链接全部可用（已本地 grep 验证标题与锚点拼写匹配 GitHub markdown 自动锚点规则）
- [ ] 完整 JSON / 配置块在三篇里只出现一次（已 grep 验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)