### PR TITLE
fix(conan): 对齐 conan_install 的 build_type 与 CMake preset (closes #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,17 @@ jobs:
             cxx: g++-13
             extra-config: -DMCPP_ENABLE_SANITIZERS=ON
 
-          # TODO(conan): re-enable once CMakeDeps + find_package(GTest CONFIG)
-          # path is debugged. Symptom is "fatal error: gtest/gtest.h: No such
-          # file or directory" at build time even though configure succeeds.
-          # Likely root cause: <Pkg>Config.cmake placement under --output-folder
-          # doesn't match where CMAKE_PREFIX_PATH (set by conan_toolchain.cmake)
-          # tells find_package to look. Steps and conanfile.txt notes are kept
-          # below in this file so re-enabling is just removing the comment-out.
-          # - name: linux-gcc-conan
-          #   os: ubuntu-24.04
-          #   preset: gcc-relwithdebinfo-conan
-          #   cc: gcc-13
-          #   cxx: g++-13
-          #   uses-conan: true
+          # Conan path. Must pass `-s build_type=` matching the preset's
+          # CMAKE_BUILD_TYPE — otherwise CMakeDeps generates per-config target
+          # files for the wrong config and INTERFACE_INCLUDE_DIRECTORIES is
+          # empty at build time. cmake/Dependencies.cmake catches this.
+          - name: linux-gcc-conan
+            os: ubuntu-24.04
+            preset: gcc-relwithdebinfo-conan
+            cc: gcc-13
+            cxx: g++-13
+            uses-conan: true
+            build-type: RelWithDebInfo
 
           - name: windows-msvc
             os: windows-2022
@@ -131,6 +129,7 @@ jobs:
           conan install . \
             --output-folder=build/${{ matrix.preset }} \
             --build=missing \
+            -s build_type=${{ matrix.build-type }} \
             -s compiler.cppstd=23
 
       # ------------------------------------------------------------------

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -38,5 +38,29 @@ if(MCPP_BUILD_TESTS)
             "To skip tests entirely pass -DMCPP_BUILD_TESTS=OFF.")
     endif()
 
+    # Defensive check for the Conan + CMakeDeps build_type mismatch trap:
+    # CMakeDeps only emits per-config target files (GTest-Target-<lower>.cmake)
+    # for the build_type passed to `conan install -s build_type=...`. If that
+    # doesn't match CMAKE_BUILD_TYPE, the IMPORTED targets get created (so
+    # GTest_FOUND is TRUE) but their INTERFACE_INCLUDE_DIRECTORIES is wrapped
+    # in $<$<CONFIG:OtherType>:...> generator expressions that evaluate to
+    # empty under our build_type — configure passes, build later explodes with
+    # `gtest/gtest.h: No such file`. Catch this at configure time.
+    if(TARGET GTest::gtest_main AND CMAKE_BUILD_TYPE)
+        get_target_property(_mcpp_gtest_inc GTest::gtest_main INTERFACE_INCLUDE_DIRECTORIES)
+        if(_mcpp_gtest_inc)
+            string(FIND "${_mcpp_gtest_inc}" "$<$<CONFIG:" _mcpp_has_genex)
+            string(FIND "${_mcpp_gtest_inc}" "$<$<CONFIG:${CMAKE_BUILD_TYPE}>" _mcpp_has_match)
+            if(NOT _mcpp_has_genex EQUAL -1 AND _mcpp_has_match EQUAL -1)
+                message(FATAL_ERROR
+                    "GoogleTest was found but has no include directories for "
+                    "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}.\n"
+                    "This usually means `conan install` was run with a different "
+                    "build_type than the CMake preset. Re-run with: "
+                    "-s build_type=${CMAKE_BUILD_TYPE}")
+            endif()
+        endif()
+    endif()
+
     include(GoogleTest)
 endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -11,3 +11,10 @@ CMakeToolchain
 # Without a layout, --output-folder=X puts conan_toolchain.cmake directly at
 # X/conan_toolchain.cmake, which the _conan preset then references as
 # ${sourceDir}/build/${presetName}/conan_toolchain.cmake. Simple and stable.
+#
+# IMPORTANT: pass `-s build_type=<Type>` matching the CMake preset's build type
+# (e.g. -s build_type=RelWithDebInfo for *-relwithdebinfo-conan presets).
+# CMakeDeps only emits per-config target files for the requested build_type;
+# a mismatch leaves INTERFACE_INCLUDE_DIRECTORIES empty under generator
+# expressions, configure passes, build fails with `gtest/gtest.h: No such file`.
+# cmake/Dependencies.cmake guards against this with a configure-time check.

--- a/docs/conan-guide.md
+++ b/docs/conan-guide.md
@@ -415,6 +415,17 @@ build"，是日常开发的安全默认。
 
 覆盖 profile 里的 `build_type`。本仓库需要这一行，因为 profile 默认 Release。
 
+> ⚠️ **必须与 preset 的 `CMAKE_BUILD_TYPE` 完全一致**。`gcc-debug-conan` 用
+> `-s build_type=Debug`，`gcc-relwithdebinfo-conan` 用 `-s build_type=RelWithDebInfo`，
+> 类推。CMakeDeps 只为请求的 build_type 生成 per-config 目标文件
+> （`GTest-Target-<lower>.cmake` + `GTest-<lower>-x86_64-data.cmake`）；mismatch
+> 时 `find_package(GTest)` 仍然返回成功（`GTest::gtest_main` target 在
+> `GTestTargets.cmake` 里被无条件 `add_library(... INTERFACE IMPORTED)`），但
+> `INTERFACE_INCLUDE_DIRECTORIES` 被 `$<$<CONFIG:OtherType>:...>` 包起来，对当前
+> build_type 求值为空 —— configure 通过、build 时炸 `gtest/gtest.h: No such file`。
+> `cmake/Dependencies.cmake` 已经加了一道 configure 期检查捕获这种情况，撞上时会
+> 直接 FATAL_ERROR 提示重跑命令。
+
 #### `-s compiler.cppstd=23`
 
 覆盖 C++ 标准。本仓库要 C++23，profile 默认可能是 17。


### PR DESCRIPTION
## Summary

- 修复 #10：CI 上 \`linux-gcc-conan\` job configure 通过、build 时却报 \`gtest/gtest.h: No such file\` 的根因，是 \`conan install\` 没传 \`-s build_type=\`，与 preset 的 \`CMAKE_BUILD_TYPE\` 不一致；CMakeDeps 只为请求的 build_type 生成 per-config 文件，mismatch 时 \`GTest::gtest_main\` target 创建了但 include 路径求值为空。
- CI: 取消 \`linux-gcc-conan\` 注释，加 \`build-type\` matrix 字段并传到 \`conan install\`。
- CMake: \`cmake/Dependencies.cmake\` 加一道 configure 期防御检查，下次撞同一陷阱时直接 FATAL_ERROR 提示重跑命令。
- 文档: \`conanfile.txt\` 顶部注释 + \`docs/conan-guide.md\` 的 \`-s build_type\` 段落都补上这条隐式约束。

## 根因细节

CMakeDeps 写两层文件：

- \`GTestTargets.cmake\` 不带 build_type 后缀，里面 \`add_library(GTest::gtest_main INTERFACE IMPORTED)\` 是无条件的。
- \`GTest-Target-<lower>.cmake\` + \`GTest-<lower>-x86_64-data.cmake\` 才是真正定义属性的，**只为 \`conan install -s build_type=\` 请求的 build_type 生成**。

属性写法形如 \`set_property(TARGET GTest::gtest_main APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES \$<\$<CONFIG:RelWithDebInfo>:...>\>)\`。Configure 期 \`find_package(GTest CONFIG)\` 看到 target 存在就把 \`GTest_FOUND\` 置 TRUE 不报错；build 期 \`g++\` 拿到的命令行没有 \`-isystem\` —— 因为 \`\$<\$<CONFIG:Release>:...>\` 在 RelWithDebInfo 下求值为空。

## Test plan

- [x] 本地用错误 build_type (\`-s build_type=Release\` 配 \`mingw-gcc-relwithdebinfo-conan\` preset) 复现原 bug。
- [x] 加防御检查后，同一组合在 configure 期就 FATAL_ERROR，提示 \`Re-run with: -s build_type=RelWithDebInfo\`。
- [x] 正确 build_type 的 happy path：configure / build / ctest 全绿。
- [ ] CI 通过 \`linux-gcc-conan\` job。

🤖 Generated with [Claude Code](https://claude.com/claude-code)