### PR TITLE
format target 跨平台修复 + 内置 Conan host profile 集合

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
             cc: gcc-13
             cxx: g++-13
             uses-conan: true
+            conan-profile: linux-gcc
             build-type: RelWithDebInfo
 
           - name: windows-msvc
@@ -118,6 +119,11 @@ jobs:
         if: matrix.uses-conan
         run: |
           pip install --upgrade conan
+          # Default profile is required as Conan's --profile:build (used to
+          # compile build-tools), even when --profile:host points at a vendored
+          # profile under conan/profiles/. detect --force initialises it from
+          # whatever compiler is on PATH; that's fine because matrix.cc/.cxx
+          # are exported into the env below.
           conan profile detect --force
 
       - name: Conan install
@@ -127,10 +133,10 @@ jobs:
           CXX: ${{ matrix.cxx }}
         run: |
           conan install . \
+            --profile:host=./conan/profiles/${{ matrix.conan-profile }} \
             --output-folder=build/${{ matrix.preset }} \
             --build=missing \
-            -s build_type=${{ matrix.build-type }} \
-            -s compiler.cppstd=23
+            -s build_type=${{ matrix.build-type }}
 
       # ------------------------------------------------------------------
       # vcpkg: bootstrap once, cache binaries via GitHub Actions cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,22 +84,27 @@ find_program(MCPP_CLANG_FORMAT_EXECUTABLE
     DOC "clang-format binary used by the `format` target")
 
 if(MCPP_CLANG_FORMAT_EXECUTABLE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    # Drive clang-format through a cmake -P script so the targets work
+    # identically on Linux/macOS/Windows without depending on a host shell,
+    # xargs, or GNU-specific flags like `xargs -r`.
+    set(_mcpp_run_clang_format "${CMAKE_SOURCE_DIR}/cmake/RunClangFormat.cmake")
+
     add_custom_target(format
-        COMMAND ${CMAKE_COMMAND} -E echo
-            "Running ${MCPP_CLANG_FORMAT_EXECUTABLE} -i over tracked C/C++ sources..."
-        COMMAND git -C "${CMAKE_SOURCE_DIR}" ls-files
-            "*.cpp" "*.cc" "*.cxx" "*.hpp" "*.h" "*.hxx"
-            | xargs -r ${MCPP_CLANG_FORMAT_EXECUTABLE} -i
+        COMMAND ${CMAKE_COMMAND}
+            "-DCLANG_FORMAT=${MCPP_CLANG_FORMAT_EXECUTABLE}"
+            "-DSOURCE_DIR=${CMAKE_SOURCE_DIR}"
+            "-DMODE=fix"
+            -P "${_mcpp_run_clang_format}"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Formatting tracked C/C++ sources in-place via clang-format"
         VERBATIM USES_TERMINAL)
 
     add_custom_target(format-check
-        COMMAND ${CMAKE_COMMAND} -E echo
-            "Running ${MCPP_CLANG_FORMAT_EXECUTABLE} --dry-run --Werror over tracked sources..."
-        COMMAND git -C "${CMAKE_SOURCE_DIR}" ls-files
-            "*.cpp" "*.cc" "*.cxx" "*.hpp" "*.h" "*.hxx"
-            | xargs -r ${MCPP_CLANG_FORMAT_EXECUTABLE} --dry-run --Werror
+        COMMAND ${CMAKE_COMMAND}
+            "-DCLANG_FORMAT=${MCPP_CLANG_FORMAT_EXECUTABLE}"
+            "-DSOURCE_DIR=${CMAKE_SOURCE_DIR}"
+            "-DMODE=check"
+            -P "${_mcpp_run_clang_format}"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         COMMENT "Checking formatting of tracked C/C++ sources (dry-run)"
         VERBATIM USES_TERMINAL)

--- a/README.md
+++ b/README.md
@@ -193,21 +193,66 @@ MSVC 到这里就好了，零额外配置。
 ### Option B：Conan
 
 仓库提供与 vcpkg 平行的一组 `*-conan` preset，直接读 Conan 生成的 toolchain，
-无需手动 `-DCMAKE_TOOLCHAIN_FILE=`：
+无需手动 `-DCMAKE_TOOLCHAIN_FILE=`。仓库还内置了 `conan/profiles/`：把每个常见
+平台 / 工具链的 ABI（compiler / version / libcxx / runtime …）固化成 profile 文件，
+让"哪个 preset 用哪份 profile"在仓库里就是 reproducible 的，不依赖 `conan profile detect`
+在不同机器上嗅探的结果。
 
 ```bash
 # 1) 安装 Conan 2.x
 pip install --upgrade conan
 
-# 2) 让 Conan 把依赖装到与 preset 同名的 build 目录
-conan install . --output-folder=build/gcc-debug-conan --build=missing \
-    -s compiler.cppstd=23
+# 2) 首次：初始化 Conan home 的默认 build profile（构建工具用，与 host profile 不同）
+conan profile detect --force
 
-# 3) 直接用 conan preset 配置（toolchain 自动取自 build/<preset>/conan_toolchain.cmake）
+# 3) 用仓库内置的 host profile 装依赖到与 preset 同名的目录
+conan install . -pr=./conan/profiles/linux-gcc \
+    -s build_type=Debug \
+    --output-folder=build/gcc-debug-conan \
+    --build=missing
+
+# 4) 直接用 conan preset 配置（toolchain 自动取自 build/<preset>/conan_toolchain.cmake）
 cmake --preset gcc-debug-conan
 cmake --build --preset gcc-debug-conan
 ctest --preset gcc-debug-conan
 ```
+
+> ⚠️ `-s build_type=` 必须与 preset 后缀一致（`*-debug-conan` ↔ `Debug`、
+> `*-relwithdebinfo-conan` ↔ `RelWithDebInfo`，类推）。CMakeDeps 只为请求的
+> build_type 生成 per-config 目标文件；mismatch 会 configure 通过、构建炸
+> `gtest/gtest.h: No such file`。`cmake/Dependencies.cmake` 已加 configure 期
+> 防御检查，撞上时会直接 FATAL_ERROR 提示重跑。
+
+#### 内置 profile × preset 对照表
+
+| profile | 目标场景 | 配套 preset 前缀 |
+| --- | --- | --- |
+| `conan/profiles/linux-gcc`     | Linux + GCC 13（Ubuntu 24.04 / Debian 13）         | `gcc-*-conan` |
+| `conan/profiles/linux-clang`   | Linux + Clang 18 + libstdc++（Ubuntu 24.04）       | `clang-*-conan` |
+| `conan/profiles/macos-clang`   | macOS + apple-clang 16+ / libc++（Xcode 16+）      | `clang-*-conan` |
+| `conan/profiles/msvc`          | Windows + MSVC ABI（cl.exe 或 clang-cl）           | `msvc-conan` / `ninja-mc-msvc-conan` / `clang-cl-*-conan` |
+| `conan/profiles/mingw-ucrt64`  | Windows + MSYS2 **UCRT64** GCC（仓库官方支持的 MinGW 入口） | `mingw-gcc-*-conan` |
+| `conan/profiles/mingw-clang64` | Windows + MSYS2 **CLANG64** Clang + libc++          | `mingw-clang-*-conan` |
+
+每份 profile 顶部都有用法注释、版本固化说明、以及"如何在 CLI 上覆盖 compiler.version"
+的指导。MSYS2 多环境共存时的 cache aliasing 注意事项见 `mingw-ucrt64` profile 内说明。
+
+#### Windows + MSYS2 完整命令示例
+
+```bash
+# 在 MSYS2 UCRT64 shell 里：
+conan profile detect --force      # 仅首次
+conan install . -pr=./conan/profiles/mingw-ucrt64 \
+    -s build_type=RelWithDebInfo \
+    --output-folder=build/mingw-gcc-relwithdebinfo-conan \
+    --build=missing
+cmake --preset mingw-gcc-relwithdebinfo-conan
+cmake --build --preset mingw-gcc-relwithdebinfo-conan --parallel
+ctest   --preset mingw-gcc-relwithdebinfo-conan
+```
+
+CLANG64 把 `mingw-ucrt64` profile 名 + `mingw-gcc-*-conan` preset 名同时换成
+`mingw-clang64` / `mingw-clang-*-conan`。
 
 可用的 conan preset（与 vcpkg 一侧完全对称，同样四种 build type）：
 

--- a/cmake/RunClangFormat.cmake
+++ b/cmake/RunClangFormat.cmake
@@ -1,0 +1,52 @@
+# Cross-platform driver for the `format` / `format-check` build targets.
+#
+# Invoked via `cmake -P` so we never depend on a host shell, xargs, or any
+# GNU-specific extension. Required cache variables (set on the command line
+# from the parent project):
+#   CLANG_FORMAT  - absolute path to the clang-format executable
+#   SOURCE_DIR    - repository root (must contain a .git directory)
+#   MODE          - "fix" (clang-format -i) or "check" (--dry-run --Werror)
+
+if(NOT CLANG_FORMAT)
+    message(FATAL_ERROR "RunClangFormat.cmake: CLANG_FORMAT is not set")
+endif()
+if(NOT SOURCE_DIR)
+    message(FATAL_ERROR "RunClangFormat.cmake: SOURCE_DIR is not set")
+endif()
+if(NOT MODE STREQUAL "fix" AND NOT MODE STREQUAL "check")
+    message(FATAL_ERROR
+        "RunClangFormat.cmake: MODE must be 'fix' or 'check' (got '${MODE}')")
+endif()
+
+execute_process(
+    COMMAND git -C "${SOURCE_DIR}" ls-files
+        "*.cpp" "*.cc" "*.cxx" "*.hpp" "*.h" "*.hxx"
+    OUTPUT_VARIABLE _files_str
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY)
+
+if(_files_str STREQUAL "")
+    message(STATUS "No tracked C/C++ sources found; nothing to format.")
+    return()
+endif()
+
+string(REPLACE "\n" ";" _files "${_files_str}")
+
+# Make paths absolute so clang-format works regardless of cwd at invocation.
+set(_abs_files "")
+foreach(_f IN LISTS _files)
+    list(APPEND _abs_files "${SOURCE_DIR}/${_f}")
+endforeach()
+
+if(MODE STREQUAL "fix")
+    message(STATUS "Running ${CLANG_FORMAT} -i over tracked C/C++ sources...")
+    execute_process(
+        COMMAND "${CLANG_FORMAT}" -i ${_abs_files}
+        COMMAND_ERROR_IS_FATAL ANY)
+else()
+    message(STATUS
+        "Running ${CLANG_FORMAT} --dry-run --Werror over tracked sources...")
+    execute_process(
+        COMMAND "${CLANG_FORMAT}" --dry-run --Werror ${_abs_files}
+        COMMAND_ERROR_IS_FATAL ANY)
+endif()

--- a/conan/profiles/linux-clang
+++ b/conan/profiles/linux-clang
@@ -1,0 +1,21 @@
+# Linux + Clang profile for ModernCpp.
+#
+# Pairs with the clang-{debug,release,relwithdebinfo,minsizerel}-conan presets.
+# On Ubuntu 24.04, Clang 18 links against libstdc++ from g++-13 to get the C++23
+# stdlib (libc++ on apt is too old). Override compiler.version / libcxx if your
+# host setup differs.
+#
+# Usage:
+#   conan install . -pr=./conan/profiles/linux-clang \
+#       -s build_type=RelWithDebInfo \
+#       --output-folder=build/clang-relwithdebinfo-conan \
+#       --build=missing
+
+[settings]
+os=Linux
+arch=x86_64
+compiler=clang
+compiler.version=18
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+build_type=Release

--- a/conan/profiles/linux-gcc
+++ b/conan/profiles/linux-gcc
@@ -1,0 +1,21 @@
+# Linux + GCC profile for ModernCpp.
+#
+# Pairs with the gcc-{debug,release,relwithdebinfo,minsizerel}-conan presets.
+# Apt-based distros (Ubuntu 24.04 / Debian 13) install gcc-13 via the package
+# repos; on rolling distros bump compiler.version (or override on the CLI:
+# `-s compiler.version=14`).
+#
+# Usage:
+#   conan install . -pr=./conan/profiles/linux-gcc \
+#       -s build_type=RelWithDebInfo \
+#       --output-folder=build/gcc-relwithdebinfo-conan \
+#       --build=missing
+
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+build_type=Release

--- a/conan/profiles/macos-clang
+++ b/conan/profiles/macos-clang
@@ -1,0 +1,26 @@
+# macOS + (Apple) Clang profile for ModernCpp.
+#
+# Pairs with the clang-{debug,release,relwithdebinfo,minsizerel}-conan presets
+# on macOS hosts. apple-clang is what `clang` resolves to under Xcode 16+
+# (which provides C++23 library coverage).
+#
+# If you use Homebrew LLVM (`brew install llvm`) instead of Apple Clang, copy
+# this profile and change to:
+#     compiler=clang
+#     compiler.version=18
+# Apple Silicon: override `arch=armv8` on the CLI or copy and adjust here.
+#
+# Usage:
+#   conan install . -pr=./conan/profiles/macos-clang \
+#       -s build_type=RelWithDebInfo \
+#       --output-folder=build/clang-relwithdebinfo-conan \
+#       --build=missing
+
+[settings]
+os=Macos
+arch=x86_64
+compiler=apple-clang
+compiler.version=16
+compiler.cppstd=23
+compiler.libcxx=libc++
+build_type=Release

--- a/conan/profiles/mingw-clang64
+++ b/conan/profiles/mingw-clang64
@@ -1,0 +1,42 @@
+# Windows + MSYS2 CLANG64 Clang profile for ModernCpp.
+#
+# Pairs with the mingw-clang-{debug,release,relwithdebinfo,minsizerel}-conan
+# presets when run from the MSYS2 CLANG64 shell. CLANG64 ships Clang built
+# with libc++ as the default standard library, against UCRT.
+#
+# If instead you want to use Clang from the UCRT64 shell (which uses
+# libstdc++ from the gcc toolchain), copy this profile and change:
+#     compiler.libcxx = libstdc++11
+# Save the copy as e.g. `conan/profiles/mingw-ucrt64-clang` and point the CLI
+# at it. The UCRT64 shell + clang combo doesn't ship a vendored profile
+# because it's a less common setup; the cache-aliasing warning from
+# `mingw-ucrt64` applies equally there.
+#
+# ABI WARNING: CLANG64 and UCRT64 share `os=Windows / arch=x86_64` in Conan's
+# settings space — they only differ on `compiler` (clang vs gcc) and
+# `libcxx` (libc++ vs libstdc++11), which IS enough to disambiguate the
+# cache. So no CONAN_HOME juggling is needed between CLANG64 and UCRT64
+# specifically. The aliasing risk is between UCRT64 and the legacy MINGW64
+# (both gcc, both libstdc++11), which this repo does not support.
+#
+# Usage (in MSYS2 CLANG64 shell):
+#   conan install . -pr=./conan/profiles/mingw-clang64 \
+#       -s build_type=RelWithDebInfo \
+#       --output-folder=build/mingw-clang-relwithdebinfo-conan \
+#       --build=missing
+
+[settings]
+os=Windows
+arch=x86_64
+compiler=clang
+compiler.version=18
+compiler.cppstd=23
+compiler.libcxx=libc++
+build_type=Release
+
+# Lock the compiler binaries so Conan invokes CLANG64's clang/clang++, not the
+# `clang.exe` from a non-MSYS2 LLVM toolchain that may sit earlier on PATH
+# (e.g. scoop/chocolatey LLVM, or VS-bundled clang-cl). Mismatch produces
+# `corrupt .drectve` from GNU ld at the final link step.
+[conf]
+tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}

--- a/conan/profiles/mingw-ucrt64
+++ b/conan/profiles/mingw-ucrt64
@@ -1,0 +1,56 @@
+# Windows + MSYS2 UCRT64 GCC profile for ModernCpp.
+#
+# Pairs with the mingw-gcc-{debug,release,relwithdebinfo,minsizerel}-conan
+# presets. UCRT64 is the MSYS2 environment this repo officially supports
+# (MinGW-w64 GCC built against the Universal C Runtime, not legacy MSVCRT).
+#
+# Run from the MSYS2 UCRT64 shell, or with `<msys2>/ucrt64/bin` on PATH so
+# `gcc` / `g++` resolve to the UCRT64 toolchain.
+#
+# ABI WARNING — MSYS2 cache aliasing
+# ----------------------------------
+# Conan settings cannot distinguish UCRT64 (UCRT) from MINGW64 (MSVCRT) — both
+# look like `os=Windows / arch=x86_64 / compiler=gcc / libcxx=libstdc++11` to
+# Conan. If you switch between MSYS2 environments on the same machine, the
+# Conan cache will hand back the binary built under the *other* runtime,
+# producing link/runtime mismatches.
+#
+# Mitigation: if you actively use more than one MSYS2 environment, point each
+# shell at its own Conan home before invoking conan:
+#     # in your UCRT64 shell rc
+#     export CONAN_HOME=$HOME/.conan2-ucrt64
+# This repo officially recommends UCRT64 only. The legacy MINGW64 environment
+# is not supported.
+#
+# compiler.version is pinned to the MSYS2 UCRT64 default (gcc 15 as of late
+# 2025/early 2026). Override on the CLI (`-s compiler.version=14`) if your
+# local pacman snapshot is older.
+#
+# Usage:
+#   conan install . -pr=./conan/profiles/mingw-ucrt64 \
+#       -s build_type=RelWithDebInfo \
+#       --output-folder=build/mingw-gcc-relwithdebinfo-conan \
+#       --build=missing
+
+[settings]
+os=Windows
+arch=x86_64
+compiler=gcc
+compiler.version=15
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+# MSYS2 UCRT64 gcc is built with posix threads + SEH unwinding. Setting these
+# explicitly gives Conan a more accurate ABI description and lets recipes that
+# branch on threading model pick MinGW-correct paths.
+compiler.threads=posix
+compiler.exception=seh
+build_type=Release
+
+# Lock the compiler binaries so Conan invokes UCRT64's gcc/g++, not whatever
+# `cc`/`c++` happens to come first on PATH (e.g. LLVM clang++ shipped by
+# scoop/chocolatey). Without this, Conan's CMakeToolchain leaves
+# CMAKE_C_COMPILER / CMAKE_CXX_COMPILER unset and CMake may pick a foreign
+# compiler whose object files GNU ld then refuses to link, producing a
+# `corrupt .drectve` failure at the final link of dependent targets.
+[conf]
+tools.build:compiler_executables={"c": "gcc", "cpp": "g++"}

--- a/conan/profiles/msvc
+++ b/conan/profiles/msvc
@@ -1,0 +1,31 @@
+# Windows + MSVC profile for ModernCpp.
+#
+# Pairs with the msvc-conan / ninja-mc-msvc-conan / clang-cl-*-conan presets
+# (all of which target the MSVC ABI / MSVC STL).
+#
+# compiler.version mapping (Conan 2):
+#   192 -> VS 2019
+#   193 -> VS 2022 17.0 - 17.9
+#   194 -> VS 2022 17.10+ (recommended; matches windows-2022 GH runners and
+#                          the 17.10+ C++23 library improvements this repo
+#                          relies on under /std:c++latest)
+# Override on the CLI if your Visual Studio is older: `-s compiler.version=193`.
+#
+# compiler.runtime=dynamic + runtime_type matching build_type produces MD/MDd
+# linkage, which is what the bundled vcpkg `x64-windows` triplet uses too —
+# so binaries from either ecosystem are interchangeable.
+#
+# Usage (in an x64 Native Tools Command Prompt or Developer PowerShell):
+#   conan install . -pr=./conan/profiles/msvc ^
+#       -s build_type=RelWithDebInfo ^
+#       --output-folder=build/clang-cl-relwithdebinfo-conan ^
+#       --build=missing
+
+[settings]
+os=Windows
+arch=x86_64
+compiler=msvc
+compiler.version=194
+compiler.cppstd=23
+compiler.runtime=dynamic
+build_type=Release

--- a/docs/conan-guide.md
+++ b/docs/conan-guide.md
@@ -24,7 +24,8 @@
 7. [编译器矩阵下的 preset 设计](#7-编译器矩阵下的-preset-设计)
 8. [profile 进阶](#8-profile-进阶)
 9. [与 CI 的集成（前瞻）](#9-与-ci-的集成前瞻)
-10. [常见问题与排查](#10-常见问题与排查)
+10. [内置 profile（`conan/profiles/`）](#10-内置-profileconanprofiles)
+11. [常见问题与排查](#11-常见问题与排查)
 
 ---
 
@@ -504,26 +505,27 @@ Conan **完全不读** `VCPKG_TARGET_TRIPLET`。Conan 用 `[settings]` 表达 AB
 
 vcpkg 下仓库为 MinGW 提供专门的 `mingw-{gcc,clang}-*` preset 固化 triplet（详见
 [vcpkg-guide.md §6](vcpkg-guide.md#6-mingw-专题)）。Conan 下同样有平行的
-`mingw-{gcc,clang}-*-conan` preset，但 ABI 不靠 triplet 表达，而是靠 profile：
+`mingw-{gcc,clang}-*-conan` preset，但 ABI 不靠 triplet 表达，而是靠 profile。
+
+仓库已经把 MinGW 两个常见入口（UCRT64 GCC / CLANG64 Clang）的 profile 入库到
+`conan/profiles/`，详见 §10。直接用：
 
 ```bash
-# 一个针对 MinGW 的 profile（保存为 ~/.conan2/profiles/mingw-ucrt64）
-[settings]
-arch=x86_64
-build_type=Release
-compiler=gcc
-compiler.cppstd=gnu23
-compiler.libcxx=libstdc++11
-compiler.version=13
-os=Windows
+# UCRT64 GCC：
+conan install . -pr=./conan/profiles/mingw-ucrt64 \
+    -s build_type=RelWithDebInfo \
+    --output-folder=build/mingw-gcc-relwithdebinfo-conan --build=missing
+cmake --preset mingw-gcc-relwithdebinfo-conan
+
+# CLANG64 Clang：
+conan install . -pr=./conan/profiles/mingw-clang64 \
+    -s build_type=RelWithDebInfo \
+    --output-folder=build/mingw-clang-relwithdebinfo-conan --build=missing
+cmake --preset mingw-clang-relwithdebinfo-conan
 ```
 
-```bash
-conan install . -pr=mingw-ucrt64 --output-folder=build/mingw-gcc-debug-conan --build=missing
-cmake --preset mingw-gcc-debug-conan
-```
-
-`-pr=` 指定 profile，覆盖默认；`--output-folder` 必须与目标 preset 名一致。
+`-pr=` 指定 profile（`-pr` 是 `--profile:host=` 的简写）；`--output-folder` 必须与目标
+preset 名一致；`-s build_type=` 必须与 preset 后缀的 build type 一致。
 
 ### Ninja Multi-Config 是什么
 
@@ -704,7 +706,87 @@ preset，未集成 Conan**。Conan preset 仅本地可用。
 
 ---
 
-## 10. 常见问题与排查
+## 10. 内置 profile（`conan/profiles/`）
+
+仓库把每个常见目标的 host profile 入库到 `conan/profiles/`。这样做的目的是
+**让 ABI 描述变成 reproducible 的版本控制资产**，而不是依赖每台机器上
+`conan profile detect` 的嗅探结果。每份 profile 都自带顶部注释，写明用途、
+配套 preset、版本固化策略、以及如何在 CLI 上覆盖。
+
+| profile | 目标场景 | 配套 preset 前缀 |
+| --- | --- | --- |
+| `linux-gcc`     | Linux + GCC 13（Ubuntu 24.04 / Debian 13）         | `gcc-*-conan` |
+| `linux-clang`   | Linux + Clang 18 + libstdc++（Ubuntu 24.04）       | `clang-*-conan` |
+| `macos-clang`   | macOS + apple-clang 16+ / libc++（Xcode 16+）      | `clang-*-conan` |
+| `msvc`          | Windows + MSVC ABI（cl.exe 或 clang-cl）            | `msvc-conan` / `ninja-mc-msvc-conan` / `clang-cl-*-conan` |
+| `mingw-ucrt64`  | Windows + MSYS2 **UCRT64** GCC                      | `mingw-gcc-*-conan` |
+| `mingw-clang64` | Windows + MSYS2 **CLANG64** Clang + libc++          | `mingw-clang-*-conan` |
+
+用法：
+
+```bash
+conan install . -pr=./conan/profiles/<name> \
+    -s build_type=<必须与 preset 后缀一致> \
+    --output-folder=build/<presetName> \
+    --build=missing
+```
+
+**首次还需要：** `conan profile detect --force` —— 这会创建一个 _default_ profile
+作为 build profile（用于编译 cmake/ninja 等构建工具）。`-pr=` 只设了
+`--profile:host`，`--profile:build` 默认指向 `default`，所以这一步不能省略。
+如果你想完全脱离 detect，把上面的命令改成同时传两个 profile：
+
+```bash
+conan install . -pr:h=./conan/profiles/<name> -pr:b=./conan/profiles/<name> ...
+```
+
+### 为什么 MinGW profile 要写 `tools.build:compiler_executables`
+
+`mingw-ucrt64` 与 `mingw-clang64` 在 `[conf]` 段额外锁了 `tools.build:compiler_executables`：
+
+```ini
+[conf]
+tools.build:compiler_executables={"c": "gcc", "cpp": "g++"}
+```
+
+因为 Conan 默认让 CMake 自由 detect 编译器（`CMakeToolchain` 不写
+`CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER`），而 Windows 用户的 PATH 上常常
+同时存在多个编译器（MSYS2 + scoop/chocolatey LLVM + VS clang-cl 等）。
+**实测：** 在 MSYS2 UCRT64 shell 里跑 `conan install -pr=./conan/profiles/mingw-ucrt64`，
+profile 声明 `compiler=gcc`，但如果不锁 `compiler_executables`，Conan 在 build
+依赖（gtest）时 cmake 会拿到 PATH 上排在前面的 `clang++.exe`（来自 LLVM 安装），
+产出的 .obj 文件让 GNU ld 在最终链接阶段抛 `Warning: corrupt .drectve at end
+of def file` + `collect2.exe: error: ld returned 5 exit status`。
+
+锁定 `compiler_executables` 后 CMakeToolchain 会显式把 `CMAKE_*_COMPILER` 写到
+toolchain 文件，跨 PATH 污染都拿到正确的编译器。
+
+> **Linux / macOS profile 没加是因为：** 这些环境一般 PATH 干净（系统 gcc / 系统
+> clang / brew LLVM 不会三个同时撞），CI 也是用 `CC=gcc-13 CXX=g++-13` 这种带版本
+> 后缀的环境变量驱动。如果你的 Linux 机器上确实多个编译器混装，可以照葫芦画瓢
+> 在对应 profile 里加 `[conf]` 段。
+
+### MSYS2 多环境共存的 cache aliasing
+
+UCRT64 与 MINGW64（legacy MSVCRT）在 Conan 的 settings 空间下**完全相同**
+（`os=Windows / arch=x86_64 / compiler=gcc / libcxx=libstdc++11`），但 C 运行库
+ABI 不同 —— 同一份 Conan cache 路径下两套环境会互相污染。`mingw-ucrt64`
+profile 顶部注释给出了缓解方案：每个 shell 用独立的 `CONAN_HOME`：
+
+```bash
+# 在 UCRT64 shell rc 里
+export CONAN_HOME=$HOME/.conan2-ucrt64
+```
+
+CLAUDE.md 与本仓库的 `mingw-gcc-*` preset 只承诺 UCRT64，不支持 MINGW64。
+如果你只用 UCRT64 一种环境，不需要担心这件事。
+
+UCRT64（gcc）vs CLANG64（clang）则不存在这个问题：`compiler` 字段不同，Conan
+天然区分。
+
+---
+
+## 11. 常见问题与排查
 
 ### "Could not find toolchain file: conan_toolchain.cmake"
 


### PR DESCRIPTION
## Summary

两件相对独立的改动放在一个 PR：

- **`fix(cmake)`** — `format` / `format-check` target 改用 `cmake -P` 驱动，去掉 `xargs -r` 这种 GNU 扩展依赖。旧实现的 `git ls-files | xargs -r ...` 在 macOS（BSD xargs 没 -r）和 Windows（cmd.exe 没 xargs）上都跑不起来，仅靠 Linux/Make/Ninja 底层 sh -c 才"碰巧 work"。新方案用 `cmake/RunClangFormat.cmake` 脚本 + `${CMAKE_COMMAND} -P`，三平台一致。
- **`feat(conan)`** — 把每个目标的 host profile 入库到 `conan/profiles/`（linux-gcc / linux-clang / macos-clang / msvc / mingw-ucrt64 / mingw-clang64），不再依赖 `conan profile detect` 嗅探。MinGW 两个 profile 在 `[conf]` 锁 `tools.build:compiler_executables`，避免 PATH 上的非 MSYS2 LLVM clang++ 抢编译权导致 `corrupt .drectve` / `ld returned 5`。CI 的 `linux-gcc-conan` job 同步改用 vendored profile。

## Test plan

- [x] Windows + Ninja + clang-cl：`cmake --build --preset clang-cl-relwithdebinfo --target format-check` → pass
- [x] Windows + Ninja + clang-cl：`--target format` → 无 diff（说明源码本就符合格式）
- [x] Windows + MSYS2 UCRT64 + Conan 端到端：`conan install -pr=./conan/profiles/mingw-ucrt64 …` → `cmake --preset mingw-gcc-relwithdebinfo-conan` → build → ctest → 100% tests passed (5/5)
- [ ] CI 全 4 job + lint pass（待 GitHub Actions 验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)