### PR TITLE
ci: add stable required-ci aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,3 +306,26 @@ jobs:
 
       - name: clang-tidy
         run: cmake --build --preset clang-relwithdebinfo --target tidy-check
+
+  required-ci:
+    name: required-ci
+    runs-on: ubuntu-24.04
+    if: ${{ always() }}
+    needs:
+      - build-test
+      - lint
+    steps:
+      - name: Aggregate upstream job results
+        env:
+          BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+        run: |
+          echo "build-test: ${BUILD_TEST_RESULT}"
+          echo "lint: ${LINT_RESULT}"
+
+          if [ "${BUILD_TEST_RESULT}" != "success" ] || [ "${LINT_RESULT}" != "success" ]; then
+            echo "::error::required-ci failed because at least one upstream job did not succeed."
+            exit 1
+          fi
+
+          echo "required-ci passed: all upstream jobs succeeded."


### PR DESCRIPTION
## Summary
- add a stable `required-ci` workflow job that depends on `build-test` and `lint`
- fail `required-ci` if either upstream job is not `success`, so branch protection can require one stable check name
- decouple branch protection from matrix/lint job renames to avoid merge deadlocks

## Test plan
- [x] inspect workflow diff locally
- [ ] verify PR checks include `required-ci`
- [ ] verify `required-ci` passes when all upstream checks pass

Made with [Cursor](https://cursor.com)