### PR TITLE
docs(i18n): 注释统一改用中文 + 扩展 01_basics 演示与测试

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,11 @@ Conan 路径不走 vcpkg cache。完整指南见 `docs/ci-guide.md`。
   `modules/NN_*/docs/{zh-CN,en-US}.md`）；项目级 `docs/` 目录专门用于工具链指南
   （clangd / clang-format / clang-tidy / CI）。
 - 完整的模块索引与快速开始见 `README.md`。
+
+## 注释语言约定
+
+- 项目相关文件（`modules/**/*.cpp`、`modules/**/CMakeLists.txt`、顶层 `CMakeLists.txt`、`cmake/*.cmake`）里的注释一律使用**中文**。
+- 适用范围包括：文件头说明、行内注释、`//` 与 `/* … */` 注释、CMake 的 `#` 注释。
+- 标识符（变量名、函数名、target 名等）仍保持英文，以匹配 `.clang-tidy` 规则。
+- 文档文件（`*.md`）保留中英双语版本（`docs/zh-CN.md` / `docs/en-US.md`）的现有规则不变。
+- 引用标准库术语、错误信息、第三方接口名时可保留原文（例如 `std::expected`、`gtest_discover_tests`），但围绕它们的解释用中文

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(ModernCpp
     LANGUAGES C CXX)
 
 # ----------------------------------------------------------------------------
-# Guardrails
+# 防护栏
 # ----------------------------------------------------------------------------
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR
@@ -15,34 +15,32 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
 endif()
 
 # ----------------------------------------------------------------------------
-# Baseline C++ standard (per-target override available via mcpp_add_demo STANDARD)
+# 基线 C++ 标准（mcpp_add_demo 的 STANDARD 参数可针对单 target 覆盖）
 # ----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# MSVC: CMAKE_CXX_STANDARD=23 maps to /std:c++23, but parts of the C++23 library
-# (e.g. <print>, std::expected, second-batch ranges) only land under /std:c++latest
-# in current MSVC versions. Force the latest flag globally so demos using newer
-# library features still compile under the msvc preset.
+# MSVC：CMAKE_CXX_STANDARD=23 会映射到 /std:c++23，但 C++23 标准库的部分内容
+# （例如 <print>、std::expected、第二批 ranges）在当前的 MSVC 版本上只有用
+# /std:c++latest 才能启用。这里全局强制 latest，让用到这些较新库特性的 demo
+# 在 msvc preset 下也能编过。
 if(MSVC)
     add_compile_options(/std:c++latest)
 endif()
 
-# Always emit compile_commands.json for clangd.
+# 始终输出 compile_commands.json，供 clangd 使用。
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Mirror compile_commands.json into the source root so .clangd's default search
-# (which walks up from the source file) finds the active preset's DB regardless
-# of which build/<preset>/ directory the user picked. Skipped on multi-config
-# generators (VS) where compile_commands.json is not produced by CMake.
+# 把 compile_commands.json 镜像一份到源码根目录 —— .clangd 默认会从源码文件
+# 一路向上查找，这样无论用户当前用的是哪个 build/<preset>/，都能找到当前激活
+# preset 的 DB。多配置生成器（VS）下 CMake 不产 compile_commands.json，跳过此机制。
 get_property(_mcpp_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT _mcpp_is_multi_config)
-    # Drive the mirror through add_custom_command(OUTPUT ...) so the rule
-    # actually depends on the build-tree compile_commands.json. Without an
-    # explicit DEPENDS the previous ALL custom target re-ran on every build
-    # (copy_if_different made it harmless but wasteful) and never declared
-    # to Ninja that its input was the build-tree DB.
+    # 镜像动作通过 add_custom_command(OUTPUT ...) 驱动，让规则真正依赖
+    # build-tree 里的 compile_commands.json。之前用 ALL custom target 时，
+    # 没有显式 DEPENDS 会导致每次构建都重跑（虽然 copy_if_different 让它
+    # 无害，但仍是浪费），且没有把"输入是 build-tree DB"这一事实告诉 Ninja。
     add_custom_command(
         OUTPUT  "${CMAKE_SOURCE_DIR}/compile_commands.json"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -56,13 +54,13 @@ if(NOT _mcpp_is_multi_config)
         DEPENDS "${CMAKE_SOURCE_DIR}/compile_commands.json")
 endif()
 
-# Keep binaries grouped under build/<preset>/bin.
+# 把可执行文件统一放在 build/<preset>/bin 下。
 if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 endif()
 
 # ----------------------------------------------------------------------------
-# Options
+# 顶层选项
 # ----------------------------------------------------------------------------
 option(MCPP_BUILD_DEMOS        "Build per-module demo executables" ON)
 option(MCPP_BUILD_TESTS        "Build GoogleTest unit tests"       ON)
@@ -70,7 +68,7 @@ option(MCPP_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(MCPP_ENABLE_SANITIZERS  "Enable ASan (+UBSan on GCC/Clang) for Debug/RelWithDebInfo" OFF)
 
 # ----------------------------------------------------------------------------
-# CMake module path
+# CMake 模块搜索路径
 # ----------------------------------------------------------------------------
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -84,9 +82,9 @@ if(MCPP_BUILD_TESTS)
 endif()
 
 # ----------------------------------------------------------------------------
-# `format` target: run clang-format -i over every tracked C/C++ source.
-# Only registered if clang-format is on PATH (so non-developer machines still
-# configure cleanly). Skipped in non-git checkouts (e.g. tarball releases).
+# `format` target：对所有被 git 跟踪的 C/C++ 源文件原地跑 clang-format -i。
+# 仅当 PATH 中能找到 clang-format 时才注册（这样非开发机也能干净 configure）。
+# 非 git 检出（例如 tarball 发布）下也跳过。
 # ----------------------------------------------------------------------------
 find_program(MCPP_CLANG_FORMAT_EXECUTABLE
     NAMES clang-format-18 clang-format
@@ -99,9 +97,8 @@ else()
 endif()
 
 if(MCPP_CLANG_FORMAT_EXECUTABLE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    # Drive clang-format through a cmake -P script so the targets work
-    # identically on Linux/macOS/Windows without depending on a host shell,
-    # xargs, or GNU-specific flags like `xargs -r`.
+    # 通过 cmake -P 脚本驱动 clang-format，这样 Linux/macOS/Windows 上行为
+    # 完全一致 —— 不依赖宿主 shell、xargs，也不依赖 `xargs -r` 这种 GNU 扩展。
     set(_mcpp_run_clang_format "${CMAKE_SOURCE_DIR}/cmake/RunClangFormat.cmake")
 
     add_custom_target(format
@@ -126,10 +123,10 @@ if(MCPP_CLANG_FORMAT_EXECUTABLE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
 endif()
 
 # ----------------------------------------------------------------------------
-# `tidy` / `tidy-check` targets: run clang-tidy across every tracked module
-# source. Mirrors the format / format-check pair. clang-tidy needs the active
-# build's compile_commands.json, so the targets are gated on a single-config
-# generator (multi-config doesn't emit one).
+# `tidy` / `tidy-check` target：对所有被跟踪的模块源文件跑 clang-tidy。
+# 与 format / format-check 配对。clang-tidy 需要当前 build 的
+# compile_commands.json，所以这两个 target 用单配置生成器作为门槛
+# （多配置生成器不产 compile_commands.json）。
 # ----------------------------------------------------------------------------
 find_program(MCPP_CLANG_TIDY_EXECUTABLE
     NAMES clang-tidy-18 clang-tidy
@@ -170,13 +167,13 @@ if(MCPP_CLANG_TIDY_EXECUTABLE
 endif()
 
 # ----------------------------------------------------------------------------
-# Add every modules/NN_* subdirectory that has its own CMakeLists.txt.
-# New modules drop in with zero top-level edits.
+# 自动收录每个带 CMakeLists.txt 的 modules/NN_* 子目录。
+# 新增模块无需改动顶层 CMakeLists.txt。
 #
-# CONFIGURE_DEPENDS makes CMake re-evaluate the glob on every build, so adding
-# a new modules/NN_*/ directory auto-registers without a manual reconfigure.
-# The cost is one extra directory stat per build for ~15 entries — negligible
-# compared to the "I added a module and CMake silently ignored it" trap.
+# CONFIGURE_DEPENDS 让 CMake 在每次构建时重新评估 glob，所以新建一个
+# modules/NN_*/ 目录后无需手动 reconfigure 就能被收录。代价是每次构建
+# 多 ~15 次目录 stat —— 与"我加了个模块结果 CMake 静默忽略了"这种坑相比
+# 完全可以接受。
 # ----------------------------------------------------------------------------
 file(GLOB _mcpp_module_dirs
     LIST_DIRECTORIES true
@@ -193,7 +190,7 @@ foreach(_dir IN LISTS _mcpp_module_dirs)
 endforeach()
 
 # ----------------------------------------------------------------------------
-# Summary (printed at configure time)
+# 配置摘要（configure 时打印）
 # ----------------------------------------------------------------------------
 if(_mcpp_is_multi_config)
     set(_mcpp_build_type_display "multi-config: ${CMAKE_CONFIGURATION_TYPES}")

--- a/cmake/CompilerSanitizers.cmake
+++ b/cmake/CompilerSanitizers.cmake
@@ -1,26 +1,26 @@
 # CompilerSanitizers.cmake
 #
-# Optional runtime sanitizers. Controlled by MCPP_ENABLE_SANITIZERS (default OFF).
-# Exposes INTERFACE target `mcpp::sanitizers` — ModuleHelpers links every demo
-# and test against it, so turning the option on is enough to sanitize everything.
+# 可选的运行期 sanitizer。由 MCPP_ENABLE_SANITIZERS（默认 OFF）控制。
+# 暴露 INTERFACE target `mcpp::sanitizers` —— ModuleHelpers 会把每个 demo
+# 与 test 都链接到它，所以打开开关一次就能让全部 target 被检测。
 #
-# Only takes effect in Debug and RelWithDebInfo; Release/MinSizeRel stay clean
-# (sanitizers defeat the point of those configs).
+# 仅在 Debug 与 RelWithDebInfo 下生效；Release / MinSizeRel 保持干净
+# （sanitizer 会让这两个配置丧失意义）。
 #
-#   GCC / Clang (Unix-driver) : -fsanitize=address,undefined -fno-omit-frame-pointer
-#                               (compile + link flags; linker autoselects the runtime)
-#   MSVC / clang-cl           : /fsanitize=address
-#                               UBSan is not supported on the MSVC ABI.
-#                               ASan is incompatible with /RTC1, which the default
-#                               Debug flags inject — we strip /RTC1 from the Debug
-#                               flags of this build tree.
+#   GCC / Clang（Unix 驱动） : -fsanitize=address,undefined -fno-omit-frame-pointer
+#                              （编译 + 链接 flag；linker 会自动选择运行时）
+#   MSVC / clang-cl          : /fsanitize=address
+#                              MSVC ABI 不支持 UBSan。
+#                              ASan 与 /RTC1 不兼容，而默认 Debug flag 会注入
+#                              /RTC1 —— 我们会在本构建树里把 /RTC1 从 Debug
+#                              flag 中剥掉。
 #
-# Why clang-cl is grouped with MSVC, not Clang:
-# clang-cl has CMAKE_CXX_COMPILER_ID == "Clang", but it is the MSVC-compatible
-# driver — it accepts /MD/MDd, links against the MSVC CRT, and supports the
-# /fsanitize=address spelling that links the MSVC ASan runtime. Routing it
-# through the GNU/Clang branch produces "-MDd not allowed with -fsanitize=address"
-# and unresolved __asan_*/__ubsan_* symbols at link time.
+# 为什么把 clang-cl 与 MSVC 归为一组而非 Clang：
+# clang-cl 的 CMAKE_CXX_COMPILER_ID 是 "Clang"，但它是 MSVC 兼容驱动 ——
+# 接受 /MD/MDd，链 MSVC CRT，且支持 /fsanitize=address 这种链 MSVC ASan
+# 运行时的拼写。把它送进 GNU/Clang 分支会得到
+# "-MDd not allowed with -fsanitize=address" 以及链接期未解析的
+# __asan_*/__ubsan_* 符号。
 
 include_guard(GLOBAL)
 
@@ -33,8 +33,8 @@ endif()
 
 set(_san_configs $<CONFIG:Debug,RelWithDebInfo>)
 
-# MSVC ABI = cl.exe OR clang-cl. The MSVC variable is TRUE for both; that's
-# what we key on so the GNU-driver Clang (linux/mac) still hits the Unix branch.
+# MSVC ABI = cl.exe 或 clang-cl。MSVC 这个变量对两者都为 TRUE，正好用来区分
+# 走 GNU 驱动的 Clang（Linux/Mac），让后者继续走 Unix 分支。
 if(NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     set(_san_flags
         -fsanitize=address
@@ -46,17 +46,15 @@ if(NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     message(STATUS "Sanitizers: AddressSanitizer + UBSan (Debug, RelWithDebInfo)")
 
 elseif(MSVC)
-    # /fsanitize=address conflicts with /RTC1; strip it from Debug flags.
+    # /fsanitize=address 与 /RTC1 冲突；从 Debug flag 中剥掉 /RTC1。
     #
-    # CAVEAT — global side effect, not scoped to mcpp::sanitizers:
-    # this rewrites the cache variables CMAKE_*_FLAGS_{DEBUG,RELWITHDEBINFO},
-    # which CMake injects into every C/C++ target in the build tree (not just
-    # the ones that link mcpp::sanitizers). MSVC has no per-target way to
-    # un-inject /RTC1, so this is the practical option, but be aware that
-    # turning on MCPP_ENABLE_SANITIZERS under MSVC means the whole build
-    # loses /RTC1 — including any third-party subdirectory you might add
-    # later. If you need /RTC1 preserved on some targets, keep
-    # MCPP_ENABLE_SANITIZERS OFF and instrument them with ASan separately.
+    # 注意 —— 全局副作用，作用范围不限于 mcpp::sanitizers：
+    # 这里改写的是 cache 变量 CMAKE_*_FLAGS_{DEBUG,RELWITHDEBINFO}，CMake 会把
+    # 它们注入到本构建树里的每一个 C/C++ target（不仅是链了 mcpp::sanitizers
+    # 的那些）。MSVC 没有 per-target 的方式去掉 /RTC1，所以这是较实用的折衷，
+    # 但要明白：在 MSVC 下打开 MCPP_ENABLE_SANITIZERS 意味着整个构建都失去
+    # /RTC1 —— 包括之后可能 add 进来的第三方子目录。如果某些 target 必须
+    # 保留 /RTC1，那就把 MCPP_ENABLE_SANITIZERS 关闭，单独给它们启用 ASan。
     foreach(_flag_var
             CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG
             CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,10 +1,9 @@
 # CompilerWarnings.cmake
 #
-# Defines the INTERFACE target `mcpp::warnings` which carries a unified
-# warning set across GCC, Clang, and MSVC. Link any demo/test target to it
-# to pick the warnings up.
+# 定义 INTERFACE target `mcpp::warnings`，统一了在 GCC / Clang / MSVC 下的
+# 警告集合。任何 demo / test target 链接到它即可获得这套警告。
 #
-# Honors the top-level option MCPP_WARNINGS_AS_ERRORS (default OFF).
+# 受顶层选项 MCPP_WARNINGS_AS_ERRORS（默认 OFF）控制。
 
 add_library(mcpp_warnings INTERFACE)
 add_library(mcpp::warnings ALIAS mcpp_warnings)
@@ -32,8 +31,8 @@ set(_mcpp_msvc_flags
     /Zc:__cplusplus
     /Zc:preprocessor
 )
-# Note: /EHsc is the MSVC default exception model — CMake injects it for C++
-# targets automatically, so we don't repeat it here.
+# 说明：/EHsc 是 MSVC 的默认异常模型 —— CMake 会自动把它注入到 C++ target，
+# 这里就不重复添加了。
 
 target_compile_options(mcpp_warnings INTERFACE
     $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:${_mcpp_gnu_like_flags}>

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,22 +1,20 @@
 # Dependencies.cmake
 #
-# Resolves third-party dependencies via `find_package`. Users are expected
-# to provision dependencies with either vcpkg (vcpkg.json manifest) or
-# Conan (conanfile.txt) and point CMake at the resulting toolchain file.
-# See README.md for setup instructions.
+# 通过 `find_package` 解析第三方依赖。约定由用户用 vcpkg（vcpkg.json manifest）
+# 或 Conan（conanfile.txt）来准备依赖，再把对应的 toolchain 文件传给 CMake。
+# 安装步骤见 README.md。
 #
-# Currently managed deps:
-#   * GoogleTest  (only if MCPP_BUILD_TESTS is ON)
+# 当前管理的依赖：
+#   * GoogleTest（仅当 MCPP_BUILD_TESTS 为 ON 时）
 
 if(MCPP_BUILD_TESTS)
-    # MSVC CRT alignment: gtest defaults to static CRT (/MT); force shared CRT
-    # (/MD) to match this repo's vcpkg triplet (x64-windows = dynamic CRT) and
-    # CMake's default CMAKE_MSVC_RUNTIME_LIBRARY (also dynamic).
+    # MSVC CRT 对齐：gtest 默认用静态 CRT（/MT），这里强制成动态 CRT（/MD），
+    # 与本仓库使用的 vcpkg triplet（x64-windows = 动态 CRT）以及 CMake 的默认
+    # CMAKE_MSVC_RUNTIME_LIBRARY（也是动态）保持一致。
     #
-    # If you ever switch to a static-CRT triplet (x64-windows-static, etc.),
-    # change this to OFF AND set CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded"
-    # accordingly — leaving them mismatched causes LNK2038 "RuntimeLibrary
-    # mismatch" linker errors.
+    # 如果你将来切换到静态 CRT 的 triplet（x64-windows-static 等），这里改成
+    # OFF，并相应地把 CMAKE_MSVC_RUNTIME_LIBRARY 设为 "MultiThreaded" ——
+    # 二者不一致会触发 LNK2038 "RuntimeLibrary mismatch" 链接错误。
     if(MSVC)
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     endif()
@@ -38,21 +36,20 @@ if(MCPP_BUILD_TESTS)
             "To skip tests entirely pass -DMCPP_BUILD_TESTS=OFF.")
     endif()
 
-    # Defensive check for the Conan + CMakeDeps build_type mismatch trap:
-    # CMakeDeps only emits per-config target files (GTest-Target-<lower>.cmake)
-    # for the build_type passed to `conan install -s build_type=...`. If that
-    # doesn't match the active CMake config, the IMPORTED targets get created
-    # (so GTest_FOUND is TRUE) but their INTERFACE_INCLUDE_DIRECTORIES is
-    # wrapped in $<$<CONFIG:OtherType>:...> generator expressions that
-    # evaluate to empty for our config — configure passes, build later
-    # explodes with `gtest/gtest.h: No such file`. Catch this at configure time.
+    # 防御性检查 —— Conan + CMakeDeps 的 build_type 不一致陷阱：
+    # CMakeDeps 只会为 `conan install -s build_type=...` 传入的那个 build_type
+    # 生成 per-config target 文件（GTest-Target-<lower>.cmake）。如果它跟当前
+    # CMake config 不匹配，IMPORTED target 仍会被创建（GTest_FOUND = TRUE），
+    # 但它们的 INTERFACE_INCLUDE_DIRECTORIES 会被包在
+    # $<$<CONFIG:OtherType>:...> 这种 generator expression 里，针对当前 config
+    # 求值为空 —— configure 阶段一切正常，构建期才会以 `gtest/gtest.h: No
+    # such file` 炸掉。这里把它在 configure 时就拦下。
     #
-    # We need to validate against EVERY config CMake will actually drive:
-    #   * single-config (Ninja, Makefiles, ...): just CMAKE_BUILD_TYPE
-    #   * multi-config (VS, Ninja Multi-Config): every entry of
-    #     CMAKE_CONFIGURATION_TYPES — Conan's per-build-type toolchain only
-    #     populates one of them, so the others would silently break at build
-    #     time. We catch that at configure time too.
+    # 我们要对 CMake 实际驱动的每一个 config 都做校验：
+    #   * 单配置生成器（Ninja、Makefiles 等）：只有 CMAKE_BUILD_TYPE
+    #   * 多配置生成器（VS、Ninja Multi-Config）：CMAKE_CONFIGURATION_TYPES
+    #     的每一项 —— Conan 的 per-build-type toolchain 只能填充其中一个，
+    #     其它的会在构建期静默炸。我们把它也在 configure 时检出。
     if(TARGET GTest::gtest_main)
         set(_mcpp_configs_to_check)
         if(CMAKE_CONFIGURATION_TYPES)

--- a/cmake/ModuleHelpers.cmake
+++ b/cmake/ModuleHelpers.cmake
@@ -1,23 +1,23 @@
 # ModuleHelpers.cmake
 #
-# Per-module helpers that keep each modules/NN_*/CMakeLists.txt short.
+# 让每个 modules/NN_*/CMakeLists.txt 都能保持简短的辅助函数。
 #
 # mcpp_add_demo(NAME <name>
 #               SOURCES <files...>
 #               [STANDARD <n>]
 #               [LINK_LIBS <targets...>])
-#   Builds one executable per demo, linked against mcpp::warnings.
-#   Target name is "<module>__<name>" to stay globally unique.
-#   STANDARD overrides CMAKE_CXX_STANDARD for this single target.
-#   LINK_LIBS adds extra PRIVATE link dependencies (e.g. Threads::Threads)
-#   without modules having to know the internal target name pattern.
+#   每个 demo 编译成一个可执行文件，链接到 mcpp::warnings。
+#   target 名为 "<module>__<name>"，确保全局唯一。
+#   STANDARD 用于覆盖单 target 的 CMAKE_CXX_STANDARD。
+#   LINK_LIBS 追加 PRIVATE 链接依赖（例如 Threads::Threads），
+#   这样模块就不需要知道内部 target 命名规则。
 #
 # mcpp_add_test(NAME <name>
 #               SOURCES <files...>
 #               [STANDARD <n>]
 #               [LINK_LIBS <targets...>])
-#   Same as demo but additionally links GTest::gtest_main and registers
-#   test cases via gtest_discover_tests.
+#   行为同 mcpp_add_demo，但额外链接 GTest::gtest_main，
+#   并通过 gtest_discover_tests 注册测试用例。
 
 include_guard(GLOBAL)
 
@@ -63,9 +63,8 @@ function(mcpp_add_demo)
     endif()
     set_target_properties(${_target} PROPERTIES
         OUTPUT_NAME "${ARG_NAME}"
-        # Per-module output directory keeps demo / test executables from
-        # different modules from colliding when they happen to share a NAME
-        # (e.g. two modules both register a `playground` demo).
+        # 给每个模块一个独立的输出目录，避免不同模块下同名（NAME 冲突）的
+        # demo / test 可执行文件互相覆盖（例如两个模块都叫 `playground`）。
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/${_module}"
         FOLDER "modules/${_module}/demos")
     _mcpp_apply_standard(${_target} "${ARG_STANDARD}")

--- a/cmake/RunClangFormat.cmake
+++ b/cmake/RunClangFormat.cmake
@@ -1,11 +1,10 @@
-# Cross-platform driver for the `format` / `format-check` build targets.
+# `format` / `format-check` target 的跨平台驱动脚本。
 #
-# Invoked via `cmake -P` so we never depend on a host shell, xargs, or any
-# GNU-specific extension. Required cache variables (set on the command line
-# from the parent project):
-#   CLANG_FORMAT  - absolute path to the clang-format executable
-#   SOURCE_DIR    - repository root (must contain a .git directory)
-#   MODE          - "fix" (clang-format -i) or "check" (--dry-run --Werror)
+# 通过 `cmake -P` 调用，这样就不用依赖宿主 shell、xargs，也不用任何 GNU 特有
+# 的扩展。需要由父项目从命令行传入的 cache 变量：
+#   CLANG_FORMAT  - clang-format 可执行文件的绝对路径
+#   SOURCE_DIR    - 仓库根（必须包含 .git 目录）
+#   MODE          - "fix"（clang-format -i）或 "check"（--dry-run --Werror）
 
 if(NOT CLANG_FORMAT)
     message(FATAL_ERROR "RunClangFormat.cmake: CLANG_FORMAT is not set")
@@ -32,7 +31,7 @@ endif()
 
 string(REPLACE "\n" ";" _files "${_files_str}")
 
-# Make paths absolute so clang-format works regardless of cwd at invocation.
+# 把路径转成绝对路径，这样无论调用时 cwd 是什么，clang-format 都能正常工作。
 set(_abs_files "")
 foreach(_f IN LISTS _files)
     list(APPEND _abs_files "${SOURCE_DIR}/${_f}")

--- a/cmake/RunClangTidy.cmake
+++ b/cmake/RunClangTidy.cmake
@@ -1,19 +1,17 @@
-# Cross-platform driver for the `tidy` / `tidy-check` build targets.
+# `tidy` / `tidy-check` target 的跨平台驱动脚本。
 #
-# Invoked via `cmake -P` so we never depend on a host shell, xargs, or any
-# GNU-specific extension. Required cache variables (set on the command line
-# from the parent project):
-#   CLANG_TIDY        - absolute path to the clang-tidy executable
-#   SOURCE_DIR        - repository root (must contain a .git directory)
-#   BUILD_DIR         - active build directory (must contain compile_commands.json)
-#   MODE              - "fix" (clang-tidy --fix) or "check" (read-only)
+# 通过 `cmake -P` 调用，这样就不用依赖宿主 shell、xargs，也不用任何 GNU 特有
+# 的扩展。需要由父项目从命令行传入的 cache 变量：
+#   CLANG_TIDY        - clang-tidy 可执行文件的绝对路径
+#   SOURCE_DIR        - 仓库根（必须包含 .git 目录）
+#   BUILD_DIR         - 当前激活的 build 目录（必须包含 compile_commands.json）
+#   MODE              - "fix"（clang-tidy --fix）或 "check"（只读）
 #
-# The file list is derived from compile_commands.json (filtered to entries
-# under SOURCE_DIR/modules/). Driving off the CDB instead of `git ls-files`
-# means modules that get skipped at configure time (e.g. 11_error_handling
-# when <expected> is unavailable in the active toolchain's stdlib) are
-# automatically excluded from analysis — clang-tidy never sees a cpp it
-# can't look up in the CDB, so it never falls back to its default flags.
+# 待分析的源文件列表从 compile_commands.json 推导（仅保留位于
+# SOURCE_DIR/modules/ 下的条目）。基于 CDB 而非 `git ls-files`，意味着
+# configure 阶段被跳过的模块（例如当前工具链 stdlib 没有 <expected> 时
+# 的 11_error_handling）会自动从分析中排除 —— clang-tidy 不会看到 CDB 里
+# 没有的 cpp，也就不会回退到自己的默认 flag。
 
 if(NOT CLANG_TIDY)
     message(FATAL_ERROR "RunClangTidy.cmake: CLANG_TIDY is not set")
@@ -34,22 +32,22 @@ if(NOT MODE STREQUAL "fix" AND NOT MODE STREQUAL "check")
         "RunClangTidy.cmake: MODE must be 'fix' or 'check' (got '${MODE}')")
 endif()
 
-# Read compile_commands.json and pull out every entry's "file" field.
+# 读取 compile_commands.json，并取出每条记录里的 "file" 字段。
 file(READ "${BUILD_DIR}/compile_commands.json" _ccdb_str)
 string(JSON _ccdb_len ERROR_VARIABLE _err LENGTH "${_ccdb_str}")
 if(_err)
     message(FATAL_ERROR "RunClangTidy.cmake: failed to parse compile_commands.json: ${_err}")
 endif()
 
-# Keep only entries whose `file` is under SOURCE_DIR/modules/ and whose
-# extension is a C++ source. Headers don't appear in the CDB anyway.
+# 只保留 `file` 位于 SOURCE_DIR/modules/ 下、且扩展名是 C++ 源文件的条目。
+# 头文件本来就不会出现在 CDB 中。
 set(_modules_root "${SOURCE_DIR}/modules")
 set(_abs_files "")
 if(_ccdb_len GREATER 0)
     math(EXPR _last "${_ccdb_len} - 1")
     foreach(_i RANGE 0 ${_last})
         string(JSON _f GET "${_ccdb_str}" ${_i} file)
-        # Normalise path separators for the prefix check (Windows backslashes).
+        # 统一路径分隔符以便做前缀匹配（处理 Windows 反斜杠）。
         string(REPLACE "\\" "/" _f_norm "${_f}")
         string(REPLACE "\\" "/" _root_norm "${_modules_root}")
         string(LENGTH "${_root_norm}/" _root_len)

--- a/modules/01_basics/CMakeLists.txt
+++ b/modules/01_basics/CMakeLists.txt
@@ -1,10 +1,23 @@
 # modules/01_basics — 基础复习与扩展 / Basics Review & Extensions
 #
-# Demos and tests covering fundamental Modern C++ language features:
-# auto deduction, fixed-width integers, safe comparisons, <bit> helpers.
+# 演示与测试覆盖现代 C++ 的基础语言特性：
+# auto 类型推导、定长整型、安全整数比较、<bit> 辅助函数等。
 
-mcpp_add_demo(NAME auto_deduction  SOURCES demos/auto_deduction.cpp)
-mcpp_add_demo(NAME integer_safety  SOURCES demos/integer_safety.cpp)
-mcpp_add_demo(NAME bit_ops         SOURCES demos/bit_ops.cpp)
+mcpp_add_demo(NAME auto_deduction      SOURCES demos/auto_deduction.cpp)
+mcpp_add_demo(NAME integer_safety      SOURCES demos/integer_safety.cpp)
+mcpp_add_demo(NAME bit_ops             SOURCES demos/bit_ops.cpp)
+mcpp_add_demo(NAME literals_and_init   SOURCES demos/literals_and_init.cpp)
+mcpp_add_demo(NAME enum_scoped         SOURCES demos/enum_scoped.cpp)
+mcpp_add_demo(NAME lambdas             SOURCES demos/lambdas.cpp)
+mcpp_add_demo(NAME polymorphism        SOURCES demos/polymorphism.cpp)
+mcpp_add_demo(NAME spaceship           SOURCES demos/spaceship.cpp)
+mcpp_add_demo(NAME attributes          SOURCES demos/attributes.cpp)
+mcpp_add_demo(NAME control_flow        SOURCES demos/control_flow.cpp)
+mcpp_add_demo(NAME floating_point      SOURCES demos/floating_point.cpp)
 
-mcpp_add_test(NAME test_basics     SOURCES tests/test_basics.cpp)
+mcpp_add_test(NAME test_basics         SOURCES tests/test_basics.cpp)
+mcpp_add_test(NAME test_lambda         SOURCES tests/test_lambda.cpp)
+mcpp_add_test(NAME test_enum           SOURCES tests/test_enum.cpp)
+mcpp_add_test(NAME test_polymorphism   SOURCES tests/test_polymorphism.cpp)
+mcpp_add_test(NAME test_spaceship      SOURCES tests/test_spaceship.cpp)
+mcpp_add_test(NAME test_floating_point SOURCES tests/test_floating_point.cpp)

--- a/modules/01_basics/demos/attributes.cpp
+++ b/modules/01_basics/demos/attributes.cpp
@@ -40,7 +40,7 @@ int main() {
         case 0:
         case 1:
             std::cout << "fast path\n";
-            [[fallthrough]];                              // 故意贯穿
+            [[fallthrough]];  // 故意贯穿
         case 2:
             std::cout << "shared tail\n";
             break;

--- a/modules/01_basics/demos/attributes.cpp
+++ b/modules/01_basics/demos/attributes.cpp
@@ -1,0 +1,51 @@
+// 标准属性：[[nodiscard]]、[[noreturn]]、[[fallthrough]]、
+// [[likely]] / [[unlikely]]、[[maybe_unused]]。
+//
+// 属性是在不引入新关键字的前提下扩展语言的官方手段。它们既向编译器
+// 表达意图，也向阅读者说明语义；以 [[fallthrough]] 为例，它一举两得：
+// 既表明"故意贯穿"，又关闭了 -Wimplicit-fallthrough 警告。
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+[[nodiscard("dropping the parsed value is almost certainly a bug")]]
+constexpr int doubleIt(int x) noexcept {
+    return x * 2;
+}
+
+[[noreturn]] void die(char const* msg) {
+    std::cerr << "fatal: " << msg << '\n';
+    std::abort();
+}
+
+constexpr int classify(int x) {
+    if (x == 0) [[unlikely]] {
+        return 0;
+    }
+    return x > 0 ? 1 : -1;
+}
+
+}  // namespace
+
+int main() {
+    [[maybe_unused]] int const reserved = 42;
+
+    std::cout << "doubleIt(7) = " << doubleIt(7) << '\n';
+    std::cout << "classify(-3) = " << classify(-3) << '\n';
+
+    int const cmd = 1;
+    switch (cmd) {
+        case 0:
+        case 1:
+            std::cout << "fast path\n";
+            [[fallthrough]];                              // 故意贯穿
+        case 2:
+            std::cout << "shared tail\n";
+            break;
+        default:
+            die("unknown command");
+    }
+    return 0;
+}

--- a/modules/01_basics/demos/auto_deduction.cpp
+++ b/modules/01_basics/demos/auto_deduction.cpp
@@ -1,9 +1,9 @@
-// auto / decltype(auto) deduction rules and a taste of structured bindings.
+// auto / decltype(auto) 推导规则，外加一点结构化绑定演示。
 //
-// Key takeaway:
-//   auto strips top-level const and references by default, so to actually bind
-//   a const reference you must spell it out: `const auto&`. `decltype(auto)`
-//   on the other hand preserves the exact expression type.
+// 关键点：
+//   auto 默认会剥掉顶层 const 与引用，所以要真正绑成 const 引用
+//   必须显式写 `const auto&`；decltype(auto) 则保留表达式的精确
+//   类型，引用与 const 都不会丢。
 
 #include <iostream>
 #include <string>
@@ -20,9 +20,9 @@ std::string const& source() {
 }  // namespace
 
 int main() {
-    auto a = source();            // std::string          (copy)
-    auto const& b = source();     // std::string const&   (no copy)
-    decltype(auto) c = source();  // std::string const&
+    auto a = source();            // std::string          （发生了拷贝）
+    auto const& b = source();     // std::string const&   （不拷贝）
+    decltype(auto) c = source();  // std::string const&   （保留引用与 const）
 
     static_assert(std::is_same_v<decltype(a), std::string>);
     static_assert(std::is_same_v<decltype(b), std::string const&>);
@@ -32,7 +32,7 @@ int main() {
               << "const auto& b: " << b << '\n'
               << "decltype(auto) c: " << c << '\n';
 
-    // Structured bindings unpack aggregates/tuples.
+    // 结构化绑定可以拆解聚合体 / 元组。
     std::pair p{42, std::string{"answer"}};
     auto const& [value, label] = p;
     std::cout << label << " = " << value << '\n';

--- a/modules/01_basics/demos/bit_ops.cpp
+++ b/modules/01_basics/demos/bit_ops.cpp
@@ -1,8 +1,8 @@
-// Highlights from <bit> (C++20) plus std::bit_cast for float punning.
+// <bit>（C++20）的常用辅助函数，外加用 std::bit_cast 查看浮点位模式。
 //
-// All <bit> helpers require unsigned integer inputs. For signed / floating
-// values, std::bit_cast reinterprets the bit pattern without undefined
-// behaviour (unlike C-style casts through pointers).
+// <bit> 里所有函数都要求无符号整数输入；对带符号 / 浮点值，
+// std::bit_cast 可以在不引入 UB 的前提下重解释位模式
+// （比通过指针 C 风格转型安全得多）。
 
 #include <bit>
 #include <cstdint>
@@ -19,7 +19,7 @@ int main() {
     std::cout << "countr_zero(x)      = " << std::countr_zero(kX) << '\n';
     std::cout << "popcount(0b1011u)   = " << std::popcount(0b1011U) << '\n';
 
-    // Inspect the IEEE-754 bit pattern of a float without UB.
+    // 不触发 UB 地查看 IEEE-754 浮点的位模式。
     constexpr float kF = -0.0F;
     auto const bits = std::bit_cast<std::uint32_t>(kF);
     std::cout << "bits(-0.0f)         = 0x" << std::hex << bits << std::dec << '\n';

--- a/modules/01_basics/demos/control_flow.cpp
+++ b/modules/01_basics/demos/control_flow.cpp
@@ -1,0 +1,51 @@
+// C++17 / C++20 控制流人体工学改进：
+//   - 带初始化器的 if / switch（C++17）
+//   - switch 内使用 using enum（C++20）
+//   - 带初始化器的范围 for（C++20）
+//
+// 初始化器把变量名约束在所属语句中，避免泄漏到外层作用域。
+// 配合 std::map / std::find 这种返回迭代器的接口尤其顺手。
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+enum class Status { Ok, Warn, Err };
+
+}  // namespace
+
+int main() {
+    std::map<std::string, int> const scores{{"Alice", 90}, {"Bob", 72}};
+
+    if (auto const it = scores.find("Alice"); it != scores.end()) {
+        std::cout << it->first << " = " << it->second << '\n';
+    } else {
+        std::cout << "not found\n";
+    }
+
+    Status const status = Status::Warn;
+    switch (status) {
+        using enum Status;
+        case Ok:
+            std::cout << "ok\n";
+            break;
+        case Warn:
+            std::cout << "warn\n";
+            break;
+        case Err:
+            std::cout << "err\n";
+            break;
+    }
+
+    // 带初始化器的范围 for —— 临时 vec 仅在循环范围内存活，
+    // 循环结束立即销毁，不污染外层作用域。
+    for (auto const vec = std::vector{1, 2, 3, 4}; auto const& n : vec) {
+        std::cout << n << ' ';
+    }
+    std::cout << '\n';
+
+    return 0;
+}

--- a/modules/01_basics/demos/control_flow.cpp
+++ b/modules/01_basics/demos/control_flow.cpp
@@ -6,6 +6,7 @@
 // 初始化器把变量名约束在所属语句中，避免泄漏到外层作用域。
 // 配合 std::map / std::find 这种返回迭代器的接口尤其顺手。
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <string>
@@ -13,7 +14,7 @@
 
 namespace {
 
-enum class Status { Ok, Warn, Err };
+enum class Status : std::uint8_t { Ok, Warn, Err };
 
 }  // namespace
 

--- a/modules/01_basics/demos/enum_scoped.cpp
+++ b/modules/01_basics/demos/enum_scoped.cpp
@@ -1,0 +1,60 @@
+// 有作用域枚举（C++11）、显式底层类型、std::to_underlying（C++23）、
+// using enum（C++20），以及标志位风格的运算符重载。
+//
+// 有作用域枚举解决了 C 风格枚举的两大痛点：名字污染、向 int 的隐式转换。
+// 下面的位标志模式说明了它的"代价"：你必须自己重新提供位运算。
+
+#include <cstdint>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+enum class Day : std::uint8_t { Mon = 1, Tue, Wed, Thu, Fri, Sat, Sun };
+
+enum class Flag : std::uint32_t {
+    None = 0,
+    Read = 1U << 0,
+    Write = 1U << 1,
+    Exec = 1U << 2,
+};
+
+constexpr Flag operator|(Flag a, Flag b) noexcept {
+    using T = std::underlying_type_t<Flag>;
+    return Flag{static_cast<T>(static_cast<T>(a) | static_cast<T>(b))};
+}
+
+constexpr bool has(Flag set, Flag bit) noexcept {
+    using T = std::underlying_type_t<Flag>;
+    return (static_cast<T>(set) & static_cast<T>(bit)) != 0;
+}
+
+}  // namespace
+
+int main() {
+    constexpr Day kToday = Day::Wed;
+    static_assert(std::is_same_v<std::underlying_type_t<Day>, std::uint8_t>);
+
+    // std::to_underlying 等价于 static_cast<U>(value)，但更能表达意图，
+    // 即便后续修改了底层类型也仍然正确。
+    std::cout << "today underlying = " << +std::to_underlying(kToday) << '\n';
+
+    switch (kToday) {
+        using enum Day;
+        case Mon: case Tue: case Wed: case Thu: case Fri:
+            std::cout << "weekday\n";
+            break;
+        case Sat: case Sun:
+            std::cout << "weekend\n";
+            break;
+    }
+
+    constexpr Flag kPerms = Flag::Read | Flag::Write;
+    std::cout << std::boolalpha
+              << "has Read  = " << has(kPerms, Flag::Read) << '\n'
+              << "has Write = " << has(kPerms, Flag::Write) << '\n'
+              << "has Exec  = " << has(kPerms, Flag::Exec) << '\n';
+
+    return 0;
+}

--- a/modules/01_basics/demos/enum_scoped.cpp
+++ b/modules/01_basics/demos/enum_scoped.cpp
@@ -42,17 +42,21 @@ int main() {
 
     switch (kToday) {
         using enum Day;
-        case Mon: case Tue: case Wed: case Thu: case Fri:
+        case Mon:
+        case Tue:
+        case Wed:
+        case Thu:
+        case Fri:
             std::cout << "weekday\n";
             break;
-        case Sat: case Sun:
+        case Sat:
+        case Sun:
             std::cout << "weekend\n";
             break;
     }
 
     constexpr Flag kPerms = Flag::Read | Flag::Write;
-    std::cout << std::boolalpha
-              << "has Read  = " << has(kPerms, Flag::Read) << '\n'
+    std::cout << std::boolalpha << "has Read  = " << has(kPerms, Flag::Read) << '\n'
               << "has Write = " << has(kPerms, Flag::Write) << '\n'
               << "has Exec  = " << has(kPerms, Flag::Exec) << '\n';
 

--- a/modules/01_basics/demos/enum_scoped.cpp
+++ b/modules/01_basics/demos/enum_scoped.cpp
@@ -29,7 +29,9 @@ enum class Flag : std::uint8_t {
 
 constexpr Flag operator|(Flag a, Flag b) noexcept {
     using T = std::underlying_type_t<Flag>;
-    return Flag{static_cast<T>(a) | static_cast<T>(b)};
+    // 注意：uint8_t 在表达式中会被提升为 int，所以外层显式转回 T 不是冗余的，
+    // 缺了它在 clang 下会触发 -Wc++11-narrowing。
+    return static_cast<Flag>(static_cast<T>(static_cast<T>(a) | static_cast<T>(b)));
 }
 
 constexpr bool has(Flag set, Flag bit) noexcept {

--- a/modules/01_basics/demos/enum_scoped.cpp
+++ b/modules/01_basics/demos/enum_scoped.cpp
@@ -13,16 +13,23 @@ namespace {
 
 enum class Day : std::uint8_t { Mon = 1, Tue, Wed, Thu, Fri, Sat, Sun };
 
-enum class Flag : std::uint32_t {
+// 位标志枚举：所有 1~7 的组合都列在 enumerator 中，避免 clang-analyzer
+// 抱怨 `Read | Write` 的结果（=3）不在枚举的合法值集合内。底层类型选
+// std::uint8_t —— 当前只用 3 个位，1 字节足够。
+enum class Flag : std::uint8_t {
     None = 0,
-    Read = 1U << 0,
-    Write = 1U << 1,
-    Exec = 1U << 2,
+    Read = 1U << 0U,
+    Write = 1U << 1U,
+    ReadWrite = Read | Write,
+    Exec = 1U << 2U,
+    ReadExec = Read | Exec,
+    WriteExec = Write | Exec,
+    All = Read | Write | Exec,
 };
 
 constexpr Flag operator|(Flag a, Flag b) noexcept {
     using T = std::underlying_type_t<Flag>;
-    return Flag{static_cast<T>(static_cast<T>(a) | static_cast<T>(b))};
+    return Flag{static_cast<T>(a) | static_cast<T>(b)};
 }
 
 constexpr bool has(Flag set, Flag bit) noexcept {

--- a/modules/01_basics/demos/floating_point.cpp
+++ b/modules/01_basics/demos/floating_point.cpp
@@ -14,8 +14,7 @@ int main() {
     constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
     constexpr double kInf = std::numeric_limits<double>::infinity();
 
-    std::cout << std::boolalpha
-              << "NaN == NaN  = " << (kNaN == kNaN) << '\n'
+    std::cout << std::boolalpha << "NaN == NaN  = " << (kNaN == kNaN) << '\n'
               << "NaN != NaN  = " << (kNaN != kNaN) << '\n'
               << "NaN <  1.0  = " << (kNaN < 1.0) << '\n'
               << "isnan(NaN)  = " << std::isnan(kNaN) << '\n'
@@ -25,11 +24,10 @@ int main() {
     constexpr float kPlusZero = 0.0F;
     constexpr float kMinusZero = -0.0F;
     std::cout << "+0.0f == -0.0f          : " << (kPlusZero == kMinusZero) << '\n';
-    std::cout << std::hex
-              << "bits(+0.0f)             : 0x"
+    std::cout << std::hex << "bits(+0.0f)             : 0x"
               << std::bit_cast<std::uint32_t>(kPlusZero) << '\n'
-              << "bits(-0.0f)             : 0x"
-              << std::bit_cast<std::uint32_t>(kMinusZero) << std::dec << '\n';
+              << "bits(-0.0f)             : 0x" << std::bit_cast<std::uint32_t>(kMinusZero)
+              << std::dec << '\n';
 
     // 超过 2^24 后，float 的 ULP >= 1，加 1 直接被舍入掉。
     // 在 1e10 处 ULP 大约是 2^11 = 2048，加法被吞没。

--- a/modules/01_basics/demos/floating_point.cpp
+++ b/modules/01_basics/demos/floating_point.cpp
@@ -1,0 +1,40 @@
+// 不离开标准库就能演示的 IEEE-754 怪异行为：
+//   - NaN 与任何值（含自身）比较都为不等
+//   - +0.0 == -0.0，但二者位模式不同
+//   - 远离零点时精度丢失（float 在约 1e7 之后 "x + 1 == x"）
+//   - std::bit_cast 不触发 UB 地查看位模式
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+int main() {
+    constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+    constexpr double kInf = std::numeric_limits<double>::infinity();
+
+    std::cout << std::boolalpha
+              << "NaN == NaN  = " << (kNaN == kNaN) << '\n'
+              << "NaN != NaN  = " << (kNaN != kNaN) << '\n'
+              << "NaN <  1.0  = " << (kNaN < 1.0) << '\n'
+              << "isnan(NaN)  = " << std::isnan(kNaN) << '\n'
+              << "Inf >  1e308 = " << (kInf > 1e308) << '\n';
+
+    // 带符号零：== 认为相等，但位模式不同。
+    constexpr float kPlusZero = 0.0F;
+    constexpr float kMinusZero = -0.0F;
+    std::cout << "+0.0f == -0.0f          : " << (kPlusZero == kMinusZero) << '\n';
+    std::cout << std::hex
+              << "bits(+0.0f)             : 0x"
+              << std::bit_cast<std::uint32_t>(kPlusZero) << '\n'
+              << "bits(-0.0f)             : 0x"
+              << std::bit_cast<std::uint32_t>(kMinusZero) << std::dec << '\n';
+
+    // 超过 2^24 后，float 的 ULP >= 1，加 1 直接被舍入掉。
+    // 在 1e10 处 ULP 大约是 2^11 = 2048，加法被吞没。
+    constexpr float kBig = 1.0e10F;
+    std::cout << "1e10f + 1.0f == 1e10f   : " << (kBig + 1.0F == kBig) << '\n';
+
+    return 0;
+}

--- a/modules/01_basics/demos/integer_safety.cpp
+++ b/modules/01_basics/demos/integer_safety.cpp
@@ -1,8 +1,7 @@
-// Fixed-width integers and the C++20 safe-integer-comparison helpers.
+// 定宽整数类型与 C++20 的安全整数比较辅助。
 //
-// The naive comparison `-1 < 1u` is `false` because the signed operand is
-// promoted to unsigned first. `std::cmp_less` / `std::in_range` give you the
-// mathematical answer without the surprise.
+// 朴素写法 `-1 < 1u` 会得到 `false`：带符号操作数会先被提升为无符号。
+// std::cmp_less / std::in_range 给出数学上正确的答案，避免这种坑。
 
 #include <cstdint>
 #include <iostream>
@@ -13,16 +12,16 @@ int main() {
     constexpr unsigned int kUnsignedValue = 1;
 
     std::cout << std::boolalpha;
-    // NOLINTNEXTLINE(clang-diagnostic-sign-conversion) - intentional: shows the naive bug
+    // NOLINTNEXTLINE(clang-diagnostic-sign-conversion) - 故意为之：演示朴素写法的坑
     std::cout << "(-1 < 1u) naive         : " << (kSignedValue < kUnsignedValue) << '\n';
     std::cout << "std::cmp_less(-1, 1u)   : " << std::cmp_less(kSignedValue, kUnsignedValue)
               << '\n';
 
-    // in_range answers "can this value be represented as T?" safely.
+    // in_range 安全地回答 "这个值能用 T 表示吗？"
     std::cout << "in_range<int8_t>(200)   : " << std::in_range<std::int8_t>(200) << '\n';
     std::cout << "in_range<int8_t>(100)   : " << std::in_range<std::int8_t>(100) << '\n';
 
-    // Prefer fixed-width types at ABI / serialization boundaries.
+    // 在 ABI / 序列化边界上优先使用定宽整数类型。
     constexpr std::uint64_t kMask = 0xFFFF'FFFF'0000'0000ULL;
     std::cout << "mask = " << std::hex << kMask << std::dec << '\n';
 

--- a/modules/01_basics/demos/lambdas.cpp
+++ b/modules/01_basics/demos/lambdas.cpp
@@ -32,8 +32,7 @@ int main() {
         counter += 100;
         return counter;
     };
-    std::cout << "cached() = " << cached()
-              << ", outer counter = " << counter << " (untouched)\n";
+    std::cout << "cached() = " << cached() << ", outer counter = " << counter << " (untouched)\n";
 
     // 泛型 lambda：闭包本身不是模板，但其 operator() 是模板。
     auto twice = [](auto const& v) { return v + v; };

--- a/modules/01_basics/demos/lambdas.cpp
+++ b/modules/01_basics/demos/lambdas.cpp
@@ -1,0 +1,46 @@
+// Lambda 捕获、mutable、泛型 lambda（C++14）、缩写函数模板（C++20）。
+//
+// Lambda 本质上是一个匿名结构体，带有 operator()。捕获列表就是它的
+// 数据成员列表；按值 / 按引用捕获分别对应 T / T& 类型。每个 lambda
+// 表达式都有唯一的闭包类型，因此任何两个 lambda 都不是同一类型。
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+// 缩写函数模板：每个 `auto` 形参隐式引入一个模板参数，
+// 等价于 `template<class A, class B> auto add(A, B)`。
+auto add(auto x, auto y) {
+    return x + y;
+}
+
+}  // namespace
+
+int main() {
+    int counter = 0;
+
+    auto bump = [&counter] { ++counter; };
+    bump();
+    bump();
+    bump();
+    std::cout << "after 3x bump, counter = " << counter << '\n';
+
+    // 按值捕获：闭包持有自己的副本。`mutable` 去掉 operator() 上的
+    // 隐式 const，让副本可以被修改。
+    auto cached = [counter]() mutable {
+        counter += 100;
+        return counter;
+    };
+    std::cout << "cached() = " << cached()
+              << ", outer counter = " << counter << " (untouched)\n";
+
+    // 泛型 lambda：闭包本身不是模板，但其 operator() 是模板。
+    auto twice = [](auto const& v) { return v + v; };
+    std::cout << "twice(21)    = " << twice(21) << '\n';
+    std::cout << "twice(\"ha\") = " << twice(std::string{"ha"}) << '\n';
+
+    std::cout << "add(1, 2.5) = " << add(1, 2.5) << '\n';
+
+    return 0;
+}

--- a/modules/01_basics/demos/literals_and_init.cpp
+++ b/modules/01_basics/demos/literals_and_init.cpp
@@ -1,0 +1,46 @@
+// C++14/17/20 的字面量与统一初始化要点。
+//
+// 涵盖：
+//   - 数字分隔符（C++14）：1'000'000、0xFF'AA、0b1010'0011
+//   - 二进制字面量（C++14）：0b...
+//   - 花括号初始化在编译期拒绝窄化转换
+//   - 聚合体的指定初始化（C++20）
+
+#include <cstdint>
+#include <iostream>
+
+namespace {
+
+struct Point {
+    int x{};
+    int y{};
+    int z{};
+};
+
+}  // namespace
+
+int main() {
+    constexpr std::uint32_t kPattern = 0xFFAA'0011U;
+    constexpr int kBigDecimal = 1'000'000;
+    constexpr unsigned kBinary = 0b1010'0011U;
+
+    std::cout << std::hex << "kPattern    = 0x" << kPattern << std::dec << '\n'
+              << "kBigDecimal = " << kBigDecimal << '\n'
+              << "kBinary     = " << kBinary << '\n';
+
+    // 取消注释下面这行就会编译失败 —— 花括号禁止窄化转换：
+    //   std::int16_t bad{kBigDecimal};   // error: narrowing
+    std::int32_t const ok{kBigDecimal};
+    std::cout << "ok          = " << ok << '\n';
+
+    // 指定初始化：显式给成员命名以提升可读性。注意 C++ 要求指定符
+    // 必须按声明顺序书写（与 C99 不同）。
+    constexpr Point kP{.x = 1, .y = 2, .z = 3};
+    std::cout << "p           = (" << kP.x << ',' << kP.y << ',' << kP.z << ")\n";
+
+    // 聚合初始化也允许省略尾部成员，省略的部分会值初始化为 {}。
+    constexpr Point kOrigin{};
+    std::cout << "origin      = (" << kOrigin.x << ',' << kOrigin.y << ',' << kOrigin.z << ")\n";
+
+    return 0;
+}

--- a/modules/01_basics/demos/polymorphism.cpp
+++ b/modules/01_basics/demos/polymorphism.cpp
@@ -1,0 +1,51 @@
+// 虚函数分派、override / final、抽象基类、虚析构函数。
+//
+// 为什么必须有虚析构：通过 Base* 删除 Derived，但基类析构是非虚的话，
+// 只会跑 Base 的析构，对象的其余部分被泄漏。任何打算被多态使用的基类
+// 都需要一个虚析构。
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+class Animal {
+public:
+    explicit Animal(std::string name) : name_{std::move(name)} {}
+    virtual ~Animal() = default;
+    virtual std::string speak() const = 0;        // 纯虚 -> 抽象类
+    std::string const& name() const { return name_; }
+
+private:
+    std::string name_;
+};
+
+class Dog : public Animal {
+public:
+    using Animal::Animal;
+    std::string speak() const override { return "woof"; }
+};
+
+// `final` 终止重写链。通过 `Cat&` / `Cat*` 调用时，编译器可放心做
+// 去虚化（devirtualization），因为不可能再有派生类重写。
+class Cat final : public Animal {
+public:
+    using Animal::Animal;
+    std::string speak() const override { return "meow"; }
+};
+
+}  // namespace
+
+int main() {
+    std::vector<std::unique_ptr<Animal>> pets;
+    pets.push_back(std::make_unique<Dog>("Rex"));
+    pets.push_back(std::make_unique<Cat>("Mochi"));
+
+    for (auto const& pet : pets) {
+        std::cout << pet->name() << " says " << pet->speak() << '\n';
+    }
+    return 0;
+}

--- a/modules/01_basics/demos/polymorphism.cpp
+++ b/modules/01_basics/demos/polymorphism.cpp
@@ -16,8 +16,8 @@ class Animal {
 public:
     explicit Animal(std::string name) : name_{std::move(name)} {}
     virtual ~Animal() = default;
-    virtual std::string speak() const = 0;  // 纯虚 -> 抽象类
-    std::string const& name() const {
+    [[nodiscard]] virtual std::string speak() const = 0;  // 纯虚 -> 抽象类
+    [[nodiscard]] std::string const& name() const {
         return name_;
     }
 
@@ -28,7 +28,7 @@ private:
 class Dog : public Animal {
 public:
     using Animal::Animal;
-    std::string speak() const override {
+    [[nodiscard]] std::string speak() const override {
         return "woof";
     }
 };
@@ -38,7 +38,7 @@ public:
 class Cat final : public Animal {
 public:
     using Animal::Animal;
-    std::string speak() const override {
+    [[nodiscard]] std::string speak() const override {
         return "meow";
     }
 };

--- a/modules/01_basics/demos/polymorphism.cpp
+++ b/modules/01_basics/demos/polymorphism.cpp
@@ -16,8 +16,10 @@ class Animal {
 public:
     explicit Animal(std::string name) : name_{std::move(name)} {}
     virtual ~Animal() = default;
-    virtual std::string speak() const = 0;        // 纯虚 -> 抽象类
-    std::string const& name() const { return name_; }
+    virtual std::string speak() const = 0;  // 纯虚 -> 抽象类
+    std::string const& name() const {
+        return name_;
+    }
 
 private:
     std::string name_;
@@ -26,7 +28,9 @@ private:
 class Dog : public Animal {
 public:
     using Animal::Animal;
-    std::string speak() const override { return "woof"; }
+    std::string speak() const override {
+        return "woof";
+    }
 };
 
 // `final` 终止重写链。通过 `Cat&` / `Cat*` 调用时，编译器可放心做
@@ -34,7 +38,9 @@ public:
 class Cat final : public Animal {
 public:
     using Animal::Animal;
-    std::string speak() const override { return "meow"; }
+    std::string speak() const override {
+        return "meow";
+    }
 };
 
 }  // namespace

--- a/modules/01_basics/demos/spaceship.cpp
+++ b/modules/01_basics/demos/spaceship.cpp
@@ -1,0 +1,48 @@
+// 三向比较运算符 `<=>` 的默认实现（C++20）。
+//
+// `operator<=> = default` 自动合成 <、<=、>、>= 四个运算；额外
+// `= default` 一个 operator==，就一并得到 == 与 !=。结果的"序类别"
+// 取所有成员中最弱的一种：只要含有 double 成员，结果就降级到
+// std::partial_ordering（NaN 之间是无序的）。
+
+#include <compare>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+struct Point {
+    int x;
+    int y;
+    auto operator<=>(Point const&) const = default;     // strong_ordering
+};
+
+struct Mass {
+    double kg;
+    auto operator<=>(Mass const&) const = default;      // partial_ordering
+};
+
+}  // namespace
+
+int main() {
+    constexpr Point kA{1, 2};
+    constexpr Point kB{1, 3};
+
+    std::cout << std::boolalpha
+              << "a <  b = " << (kA < kB) << '\n'
+              << "a == b = " << (kA == kB) << '\n'
+              << "a != b = " << (kA != kB) << '\n';
+
+    constexpr auto kCat = kA <=> kB;
+    std::cout << "is_lt(a<=>b) = " << std::is_lt(kCat) << '\n';
+
+    Mass const nan_mass{std::numeric_limits<double>::quiet_NaN()};
+    Mass const one_kg{1.0};
+    auto const fp_cat = nan_mass <=> one_kg;
+    std::cout << "nan <  1kg     = " << (nan_mass < one_kg) << '\n'
+              << "nan == 1kg     = " << (nan_mass == one_kg) << '\n'
+              << "fp_cat unordered = "
+              << (fp_cat == std::partial_ordering::unordered) << '\n';
+
+    return 0;
+}

--- a/modules/01_basics/demos/spaceship.cpp
+++ b/modules/01_basics/demos/spaceship.cpp
@@ -14,12 +14,12 @@ namespace {
 struct Point {
     int x;
     int y;
-    auto operator<=>(Point const&) const = default;     // strong_ordering
+    auto operator<=>(Point const&) const = default;  // strong_ordering
 };
 
 struct Mass {
     double kg;
-    auto operator<=>(Mass const&) const = default;      // partial_ordering
+    auto operator<=>(Mass const&) const = default;  // partial_ordering
 };
 
 }  // namespace
@@ -28,8 +28,7 @@ int main() {
     constexpr Point kA{1, 2};
     constexpr Point kB{1, 3};
 
-    std::cout << std::boolalpha
-              << "a <  b = " << (kA < kB) << '\n'
+    std::cout << std::boolalpha << "a <  b = " << (kA < kB) << '\n'
               << "a == b = " << (kA == kB) << '\n'
               << "a != b = " << (kA != kB) << '\n';
 
@@ -41,8 +40,7 @@ int main() {
     auto const fp_cat = nan_mass <=> one_kg;
     std::cout << "nan <  1kg     = " << (nan_mass < one_kg) << '\n'
               << "nan == 1kg     = " << (nan_mass == one_kg) << '\n'
-              << "fp_cat unordered = "
-              << (fp_cat == std::partial_ordering::unordered) << '\n';
+              << "fp_cat unordered = " << (fp_cat == std::partial_ordering::unordered) << '\n';
 
     return 0;
 }

--- a/modules/01_basics/tests/test_basics.cpp
+++ b/modules/01_basics/tests/test_basics.cpp
@@ -1,5 +1,5 @@
-// Covers the observable behaviour of the 01_basics demos: safe integer
-// comparison (std::cmp_xxx / std::in_range) and the <bit> helpers.
+// 覆盖 01_basics 模块各 demo 的可观测行为：安全整数比较
+// （std::cmp_xxx / std::in_range）以及 <bit> 辅助函数。
 
 #include <bit>
 #include <cstdint>
@@ -12,10 +12,10 @@ TEST(IntCmp, NegativeIsLessThanUnsigned) {
     EXPECT_TRUE(std::cmp_less(-1, 1U));
     EXPECT_FALSE(std::cmp_greater_equal(-1, 0U));
 
-    // Why std::cmp_* exists: the naive `>` silently promotes -1 to unsigned,
-    // wrapping it to UINT_MAX, so the answer flips to "true" — the trap that
-    // std::cmp_less protects you from.
-    // NOLINTNEXTLINE(clang-diagnostic-sign-conversion) - intentional, demonstrates the trap
+    // std::cmp_* 存在的意义：朴素 `>` 会把 -1 静默提升为无符号，
+    // 绕回到 UINT_MAX，结果反转为 "true" —— 这正是 std::cmp_less
+    // 帮你回避的陷阱。
+    // NOLINTNEXTLINE(clang-diagnostic-sign-conversion) - 故意为之，演示陷阱
     EXPECT_TRUE(-1 > 0U);
     EXPECT_EQ(static_cast<unsigned>(-1), std::numeric_limits<unsigned>::max());
 }

--- a/modules/01_basics/tests/test_enum.cpp
+++ b/modules/01_basics/tests/test_enum.cpp
@@ -11,16 +11,22 @@ namespace {
 
 enum class Day : std::uint8_t { Mon = 1, Tue, Wed };
 
-enum class Flag : std::uint32_t {
+// 把所有 1~7 的位组合都列出来，避免 clang-analyzer 抱怨 `Read | Write`
+// 落在 enumerator 范围之外。底层类型 uint8_t 已足够。
+enum class Flag : std::uint8_t {
     None = 0,
     Read = 1U,
     Write = 2U,
+    ReadWrite = Read | Write,
     Exec = 4U,
+    ReadExec = Read | Exec,
+    WriteExec = Write | Exec,
+    All = Read | Write | Exec,
 };
 
 constexpr Flag operator|(Flag a, Flag b) noexcept {
     using T = std::underlying_type_t<Flag>;
-    return Flag{static_cast<T>(static_cast<T>(a) | static_cast<T>(b))};
+    return Flag{static_cast<T>(a) | static_cast<T>(b)};
 }
 
 constexpr bool has(Flag set, Flag bit) noexcept {

--- a/modules/01_basics/tests/test_enum.cpp
+++ b/modules/01_basics/tests/test_enum.cpp
@@ -26,7 +26,8 @@ enum class Flag : std::uint8_t {
 
 constexpr Flag operator|(Flag a, Flag b) noexcept {
     using T = std::underlying_type_t<Flag>;
-    return Flag{static_cast<T>(a) | static_cast<T>(b)};
+    // uint8_t 在表达式里被提升为 int，外层显式转回 T 不是冗余的。
+    return static_cast<Flag>(static_cast<T>(static_cast<T>(a) | static_cast<T>(b)));
 }
 
 constexpr bool has(Flag set, Flag bit) noexcept {

--- a/modules/01_basics/tests/test_enum.cpp
+++ b/modules/01_basics/tests/test_enum.cpp
@@ -1,0 +1,43 @@
+// 有作用域枚举：显式底层类型、std::to_underlying（C++23），以及一个
+// 极简的标志位 operator|，演示如何重新引入位运算。
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+enum class Day : std::uint8_t { Mon = 1, Tue, Wed };
+
+enum class Flag : std::uint32_t {
+    None = 0,
+    Read = 1U,
+    Write = 2U,
+    Exec = 4U,
+};
+
+constexpr Flag operator|(Flag a, Flag b) noexcept {
+    using T = std::underlying_type_t<Flag>;
+    return Flag{static_cast<T>(static_cast<T>(a) | static_cast<T>(b))};
+}
+
+constexpr bool has(Flag set, Flag bit) noexcept {
+    using T = std::underlying_type_t<Flag>;
+    return (static_cast<T>(set) & static_cast<T>(bit)) != 0;
+}
+
+}  // namespace
+
+TEST(Enum, UnderlyingTypeIsAsDeclared) {
+    static_assert(std::is_same_v<std::underlying_type_t<Day>, std::uint8_t>);
+    EXPECT_EQ(std::to_underlying(Day::Wed), 3);
+}
+
+TEST(Enum, FlagsCompose) {
+    constexpr Flag kRw = Flag::Read | Flag::Write;
+    EXPECT_TRUE(has(kRw, Flag::Read));
+    EXPECT_TRUE(has(kRw, Flag::Write));
+    EXPECT_FALSE(has(kRw, Flag::Exec));
+}

--- a/modules/01_basics/tests/test_floating_point.cpp
+++ b/modules/01_basics/tests/test_floating_point.cpp
@@ -1,0 +1,36 @@
+// 把 IEEE-754 的怪异行为转化为可断言的现象。
+//
+// NaN 与任何值的所有有序比较（含 ==）都为假，而 != 为真 —— 这正是
+// 经典的"判断 NaN"惯用法（`x != x`）。带符号零比较相等，但位模式
+// 不同。超过约 2^24 后，float 的 ULP 已超过 1，加 1 直接被吞没。
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+TEST(FloatingPoint, NaNFailsAllOrderingExceptInequality) {
+    constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(kNaN == kNaN);
+    EXPECT_FALSE(kNaN < 1.0);
+    EXPECT_FALSE(kNaN > 1.0);
+    EXPECT_TRUE(kNaN != kNaN);
+    EXPECT_TRUE(std::isnan(kNaN));
+}
+
+TEST(FloatingPoint, SignedZerosCompareEqualButDifferInBits) {
+    EXPECT_EQ(0.0F, -0.0F);
+    EXPECT_EQ(std::bit_cast<std::uint32_t>(0.0F), 0U);
+    EXPECT_EQ(std::bit_cast<std::uint32_t>(-0.0F), 0x8000'0000U);
+}
+
+TEST(FloatingPoint, AddingOneVanishesAtLargeMagnitude) {
+    // 在 1e10 附近 float 的 ULP 大约是 2^11 = 2048，加 1 直接被舍掉。
+    constexpr float kBig = 1.0e10F;
+    EXPECT_EQ(kBig + 1.0F, kBig);
+    // 但 1e6 处 ULP < 1，加法仍是可观测的。
+    constexpr float kSmall = 1.0e6F;
+    EXPECT_NE(kSmall + 1.0F, kSmall);
+}

--- a/modules/01_basics/tests/test_floating_point.cpp
+++ b/modules/01_basics/tests/test_floating_point.cpp
@@ -12,12 +12,16 @@
 #include <gtest/gtest.h>
 
 TEST(FloatingPoint, NaNFailsAllOrderingExceptInequality) {
-    constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
-    EXPECT_FALSE(kNaN == kNaN);
-    EXPECT_FALSE(kNaN < 1.0);
-    EXPECT_FALSE(kNaN > 1.0);
-    EXPECT_TRUE(kNaN != kNaN);
-    EXPECT_TRUE(std::isnan(kNaN));
+    // 用 volatile 局部变量持有 NaN，阻止编译器把比较运算常量折叠 ——
+    // MSVC 的 RelWithDebInfo 在 constexpr NaN 上偶有把 `nan < 1.0`
+    // 折叠成 true 的情况，这违反 IEEE-754 但确实出现过。
+    double volatile nan_v = std::numeric_limits<double>::quiet_NaN();
+    double const nan = nan_v;
+    EXPECT_FALSE(nan == nan);
+    EXPECT_FALSE(nan < 1.0);
+    EXPECT_FALSE(nan > 1.0);
+    EXPECT_TRUE(nan != nan);
+    EXPECT_TRUE(std::isnan(nan));
 }
 
 TEST(FloatingPoint, SignedZerosCompareEqualButDifferInBits) {

--- a/modules/01_basics/tests/test_lambda.cpp
+++ b/modules/01_basics/tests/test_lambda.cpp
@@ -11,6 +11,8 @@ TEST(Lambda, CaptureByValueFreezesAtConstruction) {
     auto get = [n] { return n; };
     n = 99;
     EXPECT_EQ(get(), 1);
+    // 同时观察外层 n 已变 —— 用一下 n，绕过"值赋给后未读"的告警。
+    EXPECT_EQ(n, 99);
 }
 
 TEST(Lambda, CaptureByReferenceTracksOuter) {

--- a/modules/01_basics/tests/test_lambda.cpp
+++ b/modules/01_basics/tests/test_lambda.cpp
@@ -1,0 +1,35 @@
+// Lambda 捕获语义：按值捕获在构造时即冻结一份副本；按引用捕获跟踪
+// 外层变量；mutable 解除 operator() 上的隐式 const；泛型 lambda 的
+// operator() 自身是模板。
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(Lambda, CaptureByValueFreezesAtConstruction) {
+    int n = 1;
+    auto get = [n] { return n; };
+    n = 99;
+    EXPECT_EQ(get(), 1);
+}
+
+TEST(Lambda, CaptureByReferenceTracksOuter) {
+    int n = 1;
+    auto get = [&n] { return n; };
+    n = 99;
+    EXPECT_EQ(get(), 99);
+}
+
+TEST(Lambda, MutableLambdaModifiesItsOwnCopy) {
+    int n = 0;
+    auto step = [n]() mutable { return ++n; };
+    EXPECT_EQ(step(), 1);
+    EXPECT_EQ(step(), 2);
+    EXPECT_EQ(n, 0);
+}
+
+TEST(Lambda, GenericLambdaInstantiatesPerCallType) {
+    auto twice = [](auto const& v) { return v + v; };
+    EXPECT_EQ(twice(21), 42);
+    EXPECT_EQ(twice(std::string{"ha"}), "haha");
+}

--- a/modules/01_basics/tests/test_polymorphism.cpp
+++ b/modules/01_basics/tests/test_polymorphism.cpp
@@ -16,19 +16,19 @@ public:
     Animal(Animal&&) = default;
     Animal& operator=(Animal&&) = default;
     virtual ~Animal() = default;
-    virtual std::string speak() const = 0;
+    [[nodiscard]] virtual std::string speak() const = 0;
 };
 
 class Dog : public Animal {
 public:
-    std::string speak() const override {
+    [[nodiscard]] std::string speak() const override {
         return "woof";
     }
 };
 
 class Cat final : public Animal {
 public:
-    std::string speak() const override {
+    [[nodiscard]] std::string speak() const override {
         return "meow";
     }
 };
@@ -51,6 +51,10 @@ private:
 class CountingDerived : public CountingBase {
 public:
     CountingDerived(int* base, int* derived) : CountingBase{base}, derived_counter_{derived} {}
+    CountingDerived(CountingDerived const&) = delete;
+    CountingDerived& operator=(CountingDerived const&) = delete;
+    CountingDerived(CountingDerived&&) = delete;
+    CountingDerived& operator=(CountingDerived&&) = delete;
     ~CountingDerived() override {
         ++*derived_counter_;
     }

--- a/modules/01_basics/tests/test_polymorphism.cpp
+++ b/modules/01_basics/tests/test_polymorphism.cpp
@@ -1,0 +1,73 @@
+// 虚函数分派会选取最派生的 override；虚析构能保证通过基类指针
+// 删除时两层析构都被执行。
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class Animal {
+public:
+    Animal() = default;
+    Animal(Animal const&) = default;
+    Animal& operator=(Animal const&) = default;
+    Animal(Animal&&) = default;
+    Animal& operator=(Animal&&) = default;
+    virtual ~Animal() = default;
+    virtual std::string speak() const = 0;
+};
+
+class Dog : public Animal {
+public:
+    std::string speak() const override { return "woof"; }
+};
+
+class Cat final : public Animal {
+public:
+    std::string speak() const override { return "meow"; }
+};
+
+class CountingBase {
+public:
+    explicit CountingBase(int* counter) : counter_{counter} {}
+    CountingBase(CountingBase const&) = delete;
+    CountingBase& operator=(CountingBase const&) = delete;
+    CountingBase(CountingBase&&) = delete;
+    CountingBase& operator=(CountingBase&&) = delete;
+    virtual ~CountingBase() { ++*counter_; }
+
+private:
+    int* counter_;
+};
+
+class CountingDerived : public CountingBase {
+public:
+    CountingDerived(int* base, int* derived)
+        : CountingBase{base}, derived_counter_{derived} {}
+    ~CountingDerived() override { ++*derived_counter_; }
+
+private:
+    int* derived_counter_;
+};
+
+}  // namespace
+
+TEST(Polymorphism, VirtualDispatchPicksMostDerived) {
+    std::unique_ptr<Animal> p = std::make_unique<Cat>();
+    EXPECT_EQ(p->speak(), "meow");
+    p = std::make_unique<Dog>();
+    EXPECT_EQ(p->speak(), "woof");
+}
+
+TEST(Polymorphism, VirtualDestructorRunsBothLayers) {
+    int base = 0;
+    int derived = 0;
+    {
+        std::unique_ptr<CountingBase> p =
+            std::make_unique<CountingDerived>(&base, &derived);
+    }
+    EXPECT_EQ(base, 1);
+    EXPECT_EQ(derived, 1);
+}

--- a/modules/01_basics/tests/test_polymorphism.cpp
+++ b/modules/01_basics/tests/test_polymorphism.cpp
@@ -21,12 +21,16 @@ public:
 
 class Dog : public Animal {
 public:
-    std::string speak() const override { return "woof"; }
+    std::string speak() const override {
+        return "woof";
+    }
 };
 
 class Cat final : public Animal {
 public:
-    std::string speak() const override { return "meow"; }
+    std::string speak() const override {
+        return "meow";
+    }
 };
 
 class CountingBase {
@@ -36,7 +40,9 @@ public:
     CountingBase& operator=(CountingBase const&) = delete;
     CountingBase(CountingBase&&) = delete;
     CountingBase& operator=(CountingBase&&) = delete;
-    virtual ~CountingBase() { ++*counter_; }
+    virtual ~CountingBase() {
+        ++*counter_;
+    }
 
 private:
     int* counter_;
@@ -44,9 +50,10 @@ private:
 
 class CountingDerived : public CountingBase {
 public:
-    CountingDerived(int* base, int* derived)
-        : CountingBase{base}, derived_counter_{derived} {}
-    ~CountingDerived() override { ++*derived_counter_; }
+    CountingDerived(int* base, int* derived) : CountingBase{base}, derived_counter_{derived} {}
+    ~CountingDerived() override {
+        ++*derived_counter_;
+    }
 
 private:
     int* derived_counter_;
@@ -65,8 +72,7 @@ TEST(Polymorphism, VirtualDestructorRunsBothLayers) {
     int base = 0;
     int derived = 0;
     {
-        std::unique_ptr<CountingBase> p =
-            std::make_unique<CountingDerived>(&base, &derived);
+        std::unique_ptr<CountingBase> p = std::make_unique<CountingDerived>(&base, &derived);
     }
     EXPECT_EQ(base, 1);
     EXPECT_EQ(derived, 1);

--- a/modules/01_basics/tests/test_polymorphism.cpp
+++ b/modules/01_basics/tests/test_polymorphism.cpp
@@ -72,7 +72,8 @@ TEST(Polymorphism, VirtualDestructorRunsBothLayers) {
     int base = 0;
     int derived = 0;
     {
-        std::unique_ptr<CountingBase> p = std::make_unique<CountingDerived>(&base, &derived);
+        std::unique_ptr<CountingBase> p =
+            std::make_unique<CountingDerived>(&base, &derived);
     }
     EXPECT_EQ(base, 1);
     EXPECT_EQ(derived, 1);

--- a/modules/01_basics/tests/test_polymorphism.cpp
+++ b/modules/01_basics/tests/test_polymorphism.cpp
@@ -72,8 +72,8 @@ TEST(Polymorphism, VirtualDestructorRunsBothLayers) {
     int base = 0;
     int derived = 0;
     {
-        std::unique_ptr<CountingBase> p =
-            std::make_unique<CountingDerived>(&base, &derived);
+        using PtrT = std::unique_ptr<CountingBase>;
+        PtrT p = std::make_unique<CountingDerived>(&base, &derived);
     }
     EXPECT_EQ(base, 1);
     EXPECT_EQ(derived, 1);

--- a/modules/01_basics/tests/test_spaceship.cpp
+++ b/modules/01_basics/tests/test_spaceship.cpp
@@ -34,16 +34,12 @@ TEST(Spaceship, DefaultsAllSixComparisons) {
 }
 
 TEST(Spaceship, IntegralComparisonsAreStrong) {
-    static_assert(std::is_same_v<
-                  std::compare_three_way_result_t<Point>,
-                  std::strong_ordering>);
+    static_assert(std::is_same_v<std::compare_three_way_result_t<Point>, std::strong_ordering>);
     SUCCEED();
 }
 
 TEST(Spaceship, FloatingPointComparisonsArePartial) {
-    static_assert(std::is_same_v<
-                  std::compare_three_way_result_t<Mass>,
-                  std::partial_ordering>);
+    static_assert(std::is_same_v<std::compare_three_way_result_t<Mass>, std::partial_ordering>);
 
     Mass const nan{std::numeric_limits<double>::quiet_NaN()};
     Mass const one{1.0};

--- a/modules/01_basics/tests/test_spaceship.cpp
+++ b/modules/01_basics/tests/test_spaceship.cpp
@@ -1,0 +1,54 @@
+// `operator<=> = default` 自动合成 <、<=、>、>=。结果的"序类别"
+// 退化到最弱的成员：整数保持 strong，含 double 时因 NaN 而降级为
+// std::partial_ordering。
+
+#include <compare>
+#include <limits>
+#include <type_traits>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Point {
+    int x;
+    int y;
+    auto operator<=>(Point const&) const = default;
+};
+
+struct Mass {
+    double kg;
+    auto operator<=>(Mass const&) const = default;
+};
+
+}  // namespace
+
+TEST(Spaceship, DefaultsAllSixComparisons) {
+    constexpr Point kA{1, 2};
+    constexpr Point kB{1, 3};
+    EXPECT_TRUE(kA < kB);
+    EXPECT_TRUE(kA <= kB);
+    EXPECT_FALSE(kA > kB);
+    EXPECT_FALSE(kA == kB);
+    EXPECT_TRUE(kA != kB);
+}
+
+TEST(Spaceship, IntegralComparisonsAreStrong) {
+    static_assert(std::is_same_v<
+                  std::compare_three_way_result_t<Point>,
+                  std::strong_ordering>);
+    SUCCEED();
+}
+
+TEST(Spaceship, FloatingPointComparisonsArePartial) {
+    static_assert(std::is_same_v<
+                  std::compare_three_way_result_t<Mass>,
+                  std::partial_ordering>);
+
+    Mass const nan{std::numeric_limits<double>::quiet_NaN()};
+    Mass const one{1.0};
+    auto const cat = nan <=> one;
+    EXPECT_EQ(cat, std::partial_ordering::unordered);
+    EXPECT_FALSE(nan < one);
+    EXPECT_FALSE(nan == one);
+}

--- a/modules/02_lifetime_type_safety/CMakeLists.txt
+++ b/modules/02_lifetime_type_safety/CMakeLists.txt
@@ -1,7 +1,7 @@
 # modules/02_lifetime_type_safety — 生命周期与类型安全 / Lifetime & Type Safety
 #
-# Demos and tests covering object lifetime, storage duration,
-# references, type safety, union safety, placement new.
+# 演示与测试覆盖：对象生命周期、存储期、引用、类型安全、union 的安全使用、
+# placement new。
 
 mcpp_add_demo(NAME storage_duration SOURCES demos/storage_duration.cpp)
 

--- a/modules/02_lifetime_type_safety/demos/storage_duration.cpp
+++ b/modules/02_lifetime_type_safety/demos/storage_duration.cpp
@@ -1,8 +1,8 @@
-// Smoke demo for module 02: storage durations and lifetime printing.
+// 模块 02 的小演示：存储期与生命周期打印。
 //
-// Demonstrates static-vs-automatic storage and the construction order
-// guaranteed by the language: static is initialised before main() runs,
-// automatics in declaration order on entry to their block.
+// 演示静态存储期与自动存储期的对比，以及语言保证的构造顺序：
+// 静态对象在 main() 之前完成初始化；自动对象按声明顺序在进入其
+// 所属作用域时构造。
 
 #include <iostream>
 #include <string>

--- a/modules/02_lifetime_type_safety/tests/test_lifetime.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_lifetime.cpp
@@ -1,4 +1,4 @@
-// Smoke test for module 02: object lifetime and reference rebinding rules.
+// 模块 02 的烟雾测试：对象生命周期与引用绑定规则。
 
 #include <string>
 
@@ -44,7 +44,7 @@ TEST(Lifetime, ReferenceBindsToInitializerNotLater) {
     std::string a{"first"};
     std::string b{"second"};
     std::string& ref = a;
-    ref = b;  // assigns through ref into a; does NOT rebind ref to b
+    ref = b;  // 经由 ref 写入 a；不会把 ref 重绑到 b
     EXPECT_EQ(a, "second");
     EXPECT_EQ(&ref, &a);
 }

--- a/modules/03_multi_file/CMakeLists.txt
+++ b/modules/03_multi_file/CMakeLists.txt
@@ -1,7 +1,6 @@
 # modules/03_multi_file — 多文件编程 / Multi-file Programming
 #
-# Demos for translation units, headers, the ODR, inline variables,
-# namespaces, include guards.
+# 演示：翻译单元、头文件、ODR、内联变量（inline variables）、命名空间、include guard。
 #
-# Example:
+# 示例：
 #   mcpp_add_demo(NAME odr_basics SOURCES demos/odr_basics.cpp demos/helper.cpp)

--- a/modules/04_streams_strings/CMakeLists.txt
+++ b/modules/04_streams_strings/CMakeLists.txt
@@ -1,7 +1,7 @@
 # modules/04_streams_strings — 流与字符串 / Streams & Strings
 #
-# Demos for iostream, fstream, sstream, std::string, std::string_view,
-# formatting (<format>/<print>).
+# 演示：iostream、fstream、sstream、std::string、std::string_view、
+# 格式化（<format> / <print>）。
 #
-# Example:
+# 示例：
 #   mcpp_add_demo(NAME format_vs_iostream SOURCES demos/format_vs_iostream.cpp)

--- a/modules/05_containers_ranges_p1/CMakeLists.txt
+++ b/modules/05_containers_ranges_p1/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/05_containers_ranges_p1 — 容器、ranges 与算法 Part 1
 #
-# Demos for sequence/associative containers and range-based algorithms.
+# 演示：序列容器、关联容器，以及基于 ranges 的算法。

--- a/modules/06_containers_ranges_p2/CMakeLists.txt
+++ b/modules/06_containers_ranges_p2/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/06_containers_ranges_p2 — 容器、ranges 与算法 Part 2
 #
-# Demos for ranges views, pipelines, composition, projections.
+# 演示：ranges 的 views、管道写法、组合方式、投影（projections）。

--- a/modules/07_value_categories/CMakeLists.txt
+++ b/modules/07_value_categories/CMakeLists.txt
@@ -1,3 +1,4 @@
 # modules/07_value_categories — 值分类与移动语义 / Value Categories & Move Semantics
 #
-# Demos for lvalue/xvalue/prvalue, std::move, reference collapsing, copy elision.
+# 演示：lvalue / xvalue / prvalue，std::move，引用折叠（reference collapsing），
+# 复制省略（copy elision）。

--- a/modules/08_templates_basics/CMakeLists.txt
+++ b/modules/08_templates_basics/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/08_templates_basics — 模板基础与移动语义 / Templates Basics & Move Semantics
 #
-# Demos for function templates, class templates, perfect forwarding, CTAD.
+# 演示：函数模板、类模板、完美转发（perfect forwarding）、CTAD（类模板实参推导）。

--- a/modules/09_templates_advanced/CMakeLists.txt
+++ b/modules/09_templates_advanced/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/09_templates_advanced — 模板进阶 / Advanced Templates
 #
-# Demos for variadic templates, concepts, SFINAE, metaprogramming.
+# 演示：变参模板、concepts、SFINAE、模板元编程。

--- a/modules/10_memory/CMakeLists.txt
+++ b/modules/10_memory/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/10_memory — 内存管理 / Memory Management
 #
-# Demos for object layout, operator new/delete, smart pointers, allocators, PMR.
+# 演示：对象内存布局、operator new/delete、智能指针、分配器、PMR。

--- a/modules/11_error_handling/CMakeLists.txt
+++ b/modules/11_error_handling/CMakeLists.txt
@@ -1,12 +1,11 @@
 # modules/11_error_handling — 错误处理 / Error Handling
 #
-# Demos for exceptions, std::error_code, std::expected (C++23), assertions.
+# 演示：异常、std::error_code、std::expected（C++23）、断言。
 #
-# std::expected requires libstdc++ 12+ / libc++ 16+ / MSVC 17.4+.
-# On ubuntu-24.04 the apt clang-18 sometimes resolves to a libstdc++ that
-# does not yet expose <expected>, so guard the registration with a probe
-# rather than failing the build outright. Modules whose feature mix isn't
-# satisfied print STATUS and skip — the rest of the matrix keeps green.
+# std::expected 需要 libstdc++ 12+ / libc++ 16+ / MSVC 17.4+。
+# 在 ubuntu-24.04 上，apt 装的 clang-18 有时会拉到尚未暴露 <expected> 的
+# libstdc++，所以这里用一次探测而不是直接让构建失败。当工具链不满足
+# 所需特性组合时，本模块只打印一条 STATUS 并跳过 —— 其余矩阵继续保持绿。
 
 include(CheckCXXSourceCompiles)
 

--- a/modules/11_error_handling/demos/expected_basics.cpp
+++ b/modules/11_error_handling/demos/expected_basics.cpp
@@ -1,7 +1,7 @@
-// Smoke demo for module 11: std::expected as a value-based error channel.
+// 模块 11 的小演示：把 std::expected 当作"按值"返回的错误通道。
 //
-// std::expected<T, E> models "either a T or an E"; unlike exceptions, the
-// failure path is part of the function signature and zero-cost on success.
+// std::expected<T, E> 表示"要么是 T，要么是 E"；与异常不同，失败路径
+// 写在函数签名里，且成功路径上没有任何额外开销。
 
 #include <expected>
 #include <iostream>
@@ -22,7 +22,7 @@ std::expected<int, std::string> parse_positive(std::string_view s) {
             return std::unexpected(std::string{"non-digit: "} + c);
         }
         int const digit = c - '0';
-        // Reject before the multiply/add can overflow into UB.
+        // 在乘加运算溢出为 UB 之前先拒绝。
         if (value > (kMax - digit) / 10) {
             return std::unexpected("overflow");
         }

--- a/modules/11_error_handling/tests/test_expected.cpp
+++ b/modules/11_error_handling/tests/test_expected.cpp
@@ -1,4 +1,4 @@
-// Smoke test for module 11: std::expected happy path / error path.
+// 模块 11 的烟雾测试：std::expected 的成功路径与错误路径。
 
 #include <expected>
 #include <limits>
@@ -51,15 +51,15 @@ TEST(Expected, ValueOrFallsBackOnError) {
 }
 
 TEST(Expected, OverflowReturnsError) {
-    // 19 digits — way past INT_MAX whatever its size; overflow must be caught
-    // before the multiply/add runs into UB (otherwise UBSan fails the test).
+    // 19 位数 —— 不论 INT_MAX 多大都铁定溢出；必须在乘加进入 UB 之前
+    // 拦下（否则 UBSan 会让测试挂掉）。
     auto const r = parse_positive("9999999999999999999");
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error(), "overflow");
 }
 
 TEST(Expected, AcceptsIntMaxBoundary) {
-    // INT_MAX itself must still parse — the guard rejects only true overflow.
+    // INT_MAX 本身仍应能成功解析 —— 防护逻辑只拒绝真正的溢出。
     auto const r = parse_positive(std::to_string(std::numeric_limits<int>::max()));
     ASSERT_TRUE(r.has_value());
     EXPECT_EQ(*r, std::numeric_limits<int>::max());

--- a/modules/12_threading/CMakeLists.txt
+++ b/modules/12_threading/CMakeLists.txt
@@ -1,14 +1,13 @@
 # modules/12_threading — 多线程（新） / Threading (Modern)
 #
-# Demos for std::jthread, std::stop_token, mutex/atomic basics.
+# 演示：std::jthread、std::stop_token、mutex / atomic 基础。
 #
-# Threads::Threads is needed by jthread on Linux (-lpthread); on Windows /
-# MSVC it's a no-op but linking the imported target is harmless.
+# 在 Linux 上 jthread 需要 Threads::Threads（-lpthread）；在 Windows / MSVC
+# 上它是 no-op，但链接 imported target 没有副作用。
 #
-# std::jthread / std::stop_token need libstdc++ 11+ / MSVC STL 17.0+ /
-# libc++ 18+ (Apple Clang on macos-14 still ships an older libc++ where
-# they are missing). Probe and skip if absent — same pattern as the
-# <expected> guard in 11_error_handling.
+# std::jthread / std::stop_token 需要 libstdc++ 11+ / MSVC STL 17.0+ /
+# libc++ 18+（macos-14 上的 Apple Clang 仍然附带老版 libc++，没有这些设施）。
+# 探测一下，缺就跳过 —— 与 11_error_handling 中 <expected> 的守卫同模式。
 
 include(CheckCXXSourceCompiles)
 

--- a/modules/12_threading/demos/jthread_basics.cpp
+++ b/modules/12_threading/demos/jthread_basics.cpp
@@ -1,8 +1,8 @@
-// Smoke demo for module 12: std::jthread + std::stop_token cooperative cancel.
+// 模块 12 的小演示：std::jthread + std::stop_token 协作式取消。
 //
-// jthread joins on destruction (RAII) and threads its stop_token through to
-// the worker, so the main thread can ask the worker to wind down cleanly
-// without raw flags or detached threads.
+// jthread 在析构时自动 join（RAII），并把 stop_token 透传给工作线程；
+// 这样主线程就可以请求工作线程优雅退出，而无需自行管理裸标志或
+// 使用 detached 线程。
 
 #include <chrono>
 #include <iostream>
@@ -10,7 +10,7 @@
 #include <thread>
 
 int main() {
-    // NOLINTNEXTLINE(performance-unnecessary-value-param) - canonical jthread signature
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) - jthread 的标准签名要求按值传递
     std::jthread worker([](std::stop_token st) {
         int ticks = 0;
         while (!st.stop_requested()) {
@@ -22,6 +22,6 @@ int main() {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     worker.request_stop();
-    // jthread dtor joins automatically.
+    // jthread 析构时会自动 join。
     return 0;
 }

--- a/modules/12_threading/tests/test_jthread.cpp
+++ b/modules/12_threading/tests/test_jthread.cpp
@@ -1,4 +1,4 @@
-// Smoke test for module 12: jthread / stop_token cooperative cancellation.
+// 模块 12 的烟雾测试：jthread / stop_token 的协作式取消。
 
 #include <atomic>
 #include <latch>
@@ -7,17 +7,17 @@
 
 #include <gtest/gtest.h>
 
-// These tests previously relied on `sleep_for(20ms)` to give the worker time
-// to make progress before the main thread observed it. That's flaky on busy
-// CI runners (heavy load can suspend the worker past the deadline). std::latch
-// gives us a deterministic happens-before edge: the worker counts down once it
-// has made an observable side effect, and main blocks on wait() until then.
+// 这些用例此前依赖 `sleep_for(20ms)` 给工作线程时间做出可观测进展，
+// 但在繁忙的 CI runner 上会偶发失败（高负载可能让工作线程被挂起
+// 超过截止时间）。改用 std::latch 提供确定性的 happens-before 边：
+// 工作线程一旦产生可观测副作用就 count_down，主线程在 wait() 上阻塞，
+// 直到看到那一下信号。
 
 TEST(JThread, RequestStopCausesCooperativeExit) {
     std::atomic<int> ticks{0};
     std::latch first_tick{1};
     {
-        // NOLINTNEXTLINE(performance-unnecessary-value-param) - canonical jthread signature
+        // NOLINTNEXTLINE(performance-unnecessary-value-param) - jthread 的标准签名要求按值传递
         std::jthread worker([&](std::stop_token st) {
             ticks.fetch_add(1, std::memory_order_relaxed);
             first_tick.count_down();
@@ -28,19 +28,19 @@ TEST(JThread, RequestStopCausesCooperativeExit) {
         });
         first_tick.wait();
         worker.request_stop();
-        // jthread dtor joins.
+        // jthread 析构时会 join。
     }
     EXPECT_GT(ticks.load(), 0);
 }
 
 TEST(JThread, DestructorJoinsWithoutExplicitRequestStop) {
-    // jthread's destructor calls request_stop() then join() — so a worker
-    // that observes its stop_token is guaranteed to terminate even if the
-    // caller forgets to ask.
+    // jthread 的析构会先调用 request_stop()，再 join() —— 因此只要
+    // 工作线程检视了 stop_token，就算调用方忘了显式请求，线程也一定
+    // 会终止。
     std::atomic<bool> ran{false};
     std::latch entered{1};
     {
-        // NOLINTNEXTLINE(performance-unnecessary-value-param) - canonical jthread signature
+        // NOLINTNEXTLINE(performance-unnecessary-value-param) - jthread 的标准签名要求按值传递
         std::jthread worker([&](std::stop_token st) {
             ran.store(true);
             entered.count_down();

--- a/modules/13_concurrency_advanced/CMakeLists.txt
+++ b/modules/13_concurrency_advanced/CMakeLists.txt
@@ -1,3 +1,4 @@
 # modules/13_concurrency_advanced — 并发进阶 / Advanced Concurrency
 #
-# Demos for condition_variable, future/promise, async, memory order, latch/barrier.
+# 演示：condition_variable、future / promise、async、内存序（memory order）、
+# latch / barrier。

--- a/modules/14_move_semantics_basics/CMakeLists.txt
+++ b/modules/14_move_semantics_basics/CMakeLists.txt
@@ -1,3 +1,3 @@
-# modules/14_move_semantics_basics — Move Semantics Basics
+# modules/14_move_semantics_basics — 移动语义基础 / Move Semantics Basics
 #
-# Supplemental move-semantics demos (English-primary doc).
+# 移动语义的补充演示（对应英文为主的文档）。

--- a/modules/15_summary/CMakeLists.txt
+++ b/modules/15_summary/CMakeLists.txt
@@ -1,3 +1,3 @@
 # modules/15_summary — 补充与总结 / Supplements & Summary
 #
-# Cross-cutting wrap-up demos.
+# 跨模块的收尾性演示。


### PR DESCRIPTION
## Summary

- 在 `CLAUDE.md` 中新增"注释语言约定"章节：项目相关文件（demos / tests / `CMakeLists.txt` / `cmake/*.cmake`）的注释一律使用中文，标识符与运行期字符串保持英文。
- 扩展 `modules/01_basics`：根据 `docs/zh-CN.md` 的知识点新增 8 个 demo（`literals_and_init`、`enum_scoped`、`lambdas`、`polymorphism`、`spaceship`、`attributes`、`control_flow`、`floating_point`）与 5 个测试文件。
- 按照新约定，全量翻译现有 17 个 `.cpp` 文件、15 个模块 `CMakeLists.txt`、顶层 `CMakeLists.txt` 及 6 个 `cmake/*.cmake` 中的英文注释为中文；`message(STATUS/FATAL_ERROR ...)` 与 `COMMENT "..."` 等运行期字符串保持英文以稳定 CI/构建日志。

## Test plan

- [x] `cmake --build --preset mingw-gcc-debug --parallel 4` —— 50/50 构建任务通过
- [x] `ctest --preset mingw-gcc-debug` —— 28/28 测试通过（耗时 0.54s）
- [ ] CI 矩阵（Linux GCC/Clang、Windows MSVC/clang-cl/MinGW、macOS Clang）通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)