### PR TITLE
feat(05): 容器与迭代器模块——10 个 demo + 10 个 GTest 测试

### DIFF
--- a/modules/05_containers_ranges_p1/CMakeLists.txt
+++ b/modules/05_containers_ranges_p1/CMakeLists.txt
@@ -1,3 +1,30 @@
 # modules/05_containers_ranges_p1 — 容器、ranges 与算法 Part 1
 #
-# 演示：序列容器、关联容器，以及基于 ranges 的算法。
+# 演示与测试覆盖：
+#   - 迭代器（类别 / traits / 适配器 / 流迭代器）
+#   - 顺序容器（array / vector / vector<bool> / bitset / span / deque / list / forward_list）
+#   - 容器适配器（stack / queue / priority_queue）
+#   - 关联容器（map / set / multimap / multiset 与 unordered_* 家族）
+#   - 结构化绑定与 tuple
+
+mcpp_add_demo(NAME iterators_traits      SOURCES demos/iterators_traits.cpp)
+mcpp_add_demo(NAME iterator_adapters     SOURCES demos/iterator_adapters.cpp)
+mcpp_add_demo(NAME vector_capacity       SOURCES demos/vector_capacity.cpp)
+mcpp_add_demo(NAME vector_bool_proxy     SOURCES demos/vector_bool_proxy.cpp)
+mcpp_add_demo(NAME span_view             SOURCES demos/span_view.cpp)
+mcpp_add_demo(NAME bitset_demo           SOURCES demos/bitset_demo.cpp)
+mcpp_add_demo(NAME deque_list_demo       SOURCES demos/deque_list_demo.cpp)
+mcpp_add_demo(NAME priority_queue_demo   SOURCES demos/priority_queue_demo.cpp)
+mcpp_add_demo(NAME map_idioms            SOURCES demos/map_idioms.cpp)
+mcpp_add_demo(NAME unordered_custom_hash SOURCES demos/unordered_custom_hash.cpp)
+
+mcpp_add_test(NAME test_iterators        SOURCES tests/test_iterators.cpp)
+mcpp_add_test(NAME test_array            SOURCES tests/test_array.cpp)
+mcpp_add_test(NAME test_vector           SOURCES tests/test_vector.cpp)
+mcpp_add_test(NAME test_span             SOURCES tests/test_span.cpp)
+mcpp_add_test(NAME test_bitset           SOURCES tests/test_bitset.cpp)
+mcpp_add_test(NAME test_sequence         SOURCES tests/test_sequence.cpp)
+mcpp_add_test(NAME test_adapters         SOURCES tests/test_adapters.cpp)
+mcpp_add_test(NAME test_map              SOURCES tests/test_map.cpp)
+mcpp_add_test(NAME test_unordered        SOURCES tests/test_unordered.cpp)
+mcpp_add_test(NAME test_tuple            SOURCES tests/test_tuple.cpp)

--- a/modules/05_containers_ranges_p1/README.md
+++ b/modules/05_containers_ranges_p1/README.md
@@ -7,5 +7,46 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+本模块基于讲义系统覆盖容器与迭代器；ranges 与算法见
+`modules/06_containers_ranges_p2`。
+
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/iterators_traits.cpp` | 迭代器类别（concept）、`iterator_traits`、`advance` / `next` / `prev` / `distance` |
+| `demos/iterator_adapters.cpp` | `reverse_iterator`、`back/front/inserter`、`istream_iterator` / `ostream_iterator` |
+| `demos/vector_capacity.cpp` | `size` / `capacity`、`reserve`、`shrink_to_fit`、`erase` 返回值 |
+| `demos/vector_bool_proxy.cpp` | `vector<bool>` 代理引用（auto 推导陷阱） |
+| `demos/span_view.cpp` | `std::span`：非拥有视图、子 span、静态 vs 动态 extent |
+| `demos/bitset_demo.cpp` | `std::bitset`：位运算、`to_string` / `to_ullong` 互转 |
+| `demos/deque_list_demo.cpp` | `deque` 双端推入；`list` 的 `splice` / `merge` / `sort` / `unique` |
+| `demos/priority_queue_demo.cpp` | `stack` / `queue` / `priority_queue`（最大堆、`std::greater` 最小堆、范围构造） |
+| `demos/map_idioms.cpp` | `map`：`operator[]` vs `find`、`insert_or_assign`、`try_emplace`、节点提取 |
+| `demos/unordered_custom_hash.cpp` | `unordered_*`：自定义哈希、负载因子、桶接口 |
+
+### Tests
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `tests/test_iterators.cpp` | 迭代器 concept / traits / 反向迭代器 / 流迭代器 |
+| `tests/test_array.cpp` | `std::array` 行为、`to_array`、结构化绑定 |
+| `tests/test_vector.cpp` | 容量 / 失效边界 / `erase` 返回值 / `vector<bool>` 代理 |
+| `tests/test_span.cpp` | `span` 构造、`first` / `last` / `subspan`、`as_bytes` |
+| `tests/test_bitset.cpp` | `bitset` 位运算与互转 |
+| `tests/test_sequence.cpp` | `deque` / `list` / `forward_list` 的关键 API |
+| `tests/test_adapters.cpp` | `stack` / `queue` / `priority_queue`（默认 + 自定义比较器） |
+| `tests/test_map.cpp` | `map` / `set` / `multimap` / 节点提取 / `equal_range` |
+| `tests/test_unordered.cpp` | `unordered_*`：负载因子、桶、自定义哈希、`multimap` 等价性 |
+| `tests/test_tuple.cpp` | `tuple` / `pair` / 结构化绑定 / `std::tie` / `std::ignore` / `tuple_cat` |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的 demo 与测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    05_containers_ranges_p1__test_iterators
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 05_containers_ranges_p1
+```

--- a/modules/05_containers_ranges_p1/demos/bitset_demo.cpp
+++ b/modules/05_containers_ranges_p1/demos/bitset_demo.cpp
@@ -1,0 +1,56 @@
+// std::bitset：编译期固定长度的位数组，支持位运算与字符串/整数互转。
+//
+// 关键点：
+//   - bitset 的尺寸是模板参数，在编译期确定。
+//   - 与 vector<bool> 不同，bitset 不暴露迭代器；它把"位串"作为一等公民，
+//     直接提供 `&|^~`、`<<` / `>>`、count / any / all / none、to_string / to_ullong。
+//   - operator[] 同样返回代理（const 版本返回 bool）。
+//   - 位下标 0 是最低位（"右边"），与 to_string 的输出顺序相反。
+
+#include <bitset>
+#include <cstddef>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main() {
+    constexpr std::size_t kN = 8;
+    std::bitset<kN> a{0b1010'1100U};
+
+    std::cout << "a            = " << a << " (count=" << a.count() << ")\n";
+    std::cout << "a[0]=" << a[0] << " a[7]=" << a[7] << " (位 0 是最低位，与字符串显示左右相反)\n";
+
+    // 位运算
+    std::bitset<kN> b{0b0000'1111U};
+    std::cout << "a & b        = " << (a & b) << '\n';
+    std::cout << "a | b        = " << (a | b) << '\n';
+    std::cout << "a ^ b        = " << (a ^ b) << '\n';
+    std::cout << "~a           = " << (~a) << '\n';
+    std::cout << "a << 2       = " << (a << 2) << '\n';
+
+    // 单位修改
+    a.set(0);    // 将位 0 置 1
+    a.reset(7);  // 将位 7 置 0
+    a.flip(1);   // 翻转位 1
+    std::cout << "after set/reset/flip: " << a << '\n';
+
+    // 整体查询
+    std::cout << "any=" << a.any() << " all=" << a.all() << " none=" << a.none() << '\n';
+
+    // 边界检查：test 抛 out_of_range；operator[] 不会
+    try {
+        (void)a.test(99);
+    } catch (const std::out_of_range& e) {
+        std::cout << "test(99) threw: " << e.what() << '\n';
+    }
+
+    // 互转
+    std::cout << "to_string()  = " << a.to_string() << '\n';
+    std::cout << "to_ullong()  = " << a.to_ullong() << '\n';
+
+    // 由字符串构造（'0'/'1' 可自定义）
+    std::bitset<8> c{std::string{"xx11oo11"}, 0, std::string::npos, 'o', 'x'};
+    std::cout << "c (from str) = " << c << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/deque_list_demo.cpp
+++ b/modules/05_containers_ranges_p1/demos/deque_list_demo.cpp
@@ -1,0 +1,72 @@
+// deque：双端队列；list：双向链表 —— 各自独有 API 的演示。
+//
+// 关键点：
+//   - deque 提供 push_front/push_back 双端 O(1) 操作 + 随机访问；
+//     底层是"块（block）数组"，所以与 vector 不同，从前端推入不需要整体搬动。
+//   - list 是基于节点的双向链表，没有随机访问，但 splice / merge / sort
+//     可以在 O(1) 拼接整个区间（splice）或在 O(n log n) 内归并排序。
+//   - splice 把节点从一个 list 移到另一个 list，不发生拷贝；
+//     这是 list 相对 vector 的核心优势之一。
+
+#include <deque>
+#include <iostream>
+#include <list>
+
+namespace {
+
+template <class Container>
+void dump(const char* tag, const Container& c) {
+    std::cout << tag << ": ";
+    for (auto const& x : c) {
+        std::cout << x << ' ';
+    }
+    std::cout << '\n';
+}
+
+}  // namespace
+
+int main() {
+    // === deque ===
+    std::deque<int> dq;
+    dq.push_back(2);
+    dq.push_back(3);
+    dq.push_front(1);
+    dq.push_front(0);
+    dump("deque after 4 pushes  ", dq);  // 0 1 2 3
+    std::cout << "deque[2]              = " << dq[2] << " (随机访问)\n";
+
+    // 端点元素的引用在再次从端点 push 时仍然有效（块本身不变）
+    int& back_ref = dq.back();
+    dq.push_front(-1);
+    std::cout << "back ref still valid? " << back_ref << " (= dq.back() after push_front)\n";
+
+    // === list ===
+    std::list<int> a{1, 3, 5, 7};
+    std::list<int> b{2, 4, 6, 8};
+
+    // sort + merge：两个已排序链表合成一个（节点直接转移）
+    a.merge(b);
+    dump("list a after merge(b)", a);
+    std::cout << "list b size after merge = " << b.size() << " (节点已被移走)\n";
+
+    // splice：把整个 list 的节点接到 pos 之前
+    std::list<int> head{100, 101};
+    std::list<int> tail{200, 201};
+    head.splice(head.end(), tail);
+    dump("head after splice end ", head);
+    std::cout << "tail size = " << tail.size() << '\n';
+
+    // remove_if / unique：list 自带 O(n) 版本，比 erase + algorithm 高效
+    std::list<int> nums{1, 1, 2, 2, 2, 3, 4, 4};
+    nums.unique();  // 相邻去重 → 1 2 3 4
+    dump("after unique          ", nums);
+    nums.remove_if([](int x) { return x % 2 == 0; });
+    dump("after remove_if even  ", nums);
+
+    // sort：list 自带稳定归并排序（O(1) 额外空间）
+    std::list<int> unsorted{4, 2, 5, 1, 3};
+    unsorted.sort();
+    dump("list::sort            ", unsorted);
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/iterator_adapters.cpp
+++ b/modules/05_containers_ranges_p1/demos/iterator_adapters.cpp
@@ -1,0 +1,69 @@
+// 迭代器适配器：reverse_iterator、back/front/insert_iterator，以及流迭代器。
+//
+// 关键点：
+//   - reverse_iterator 物理底层指向"当前所引用元素之后"的位置；
+//     rit.base() 返回的就是这个底层迭代器，因此 rbegin().base() == end()。
+//   - back_inserter / front_inserter / inserter 都是输出迭代器：
+//     `*it = val` 实际触发 push_back / push_front / insert。
+//   - ostream_iterator / istream_iterator 把流伪装成迭代器，便于和算法组合。
+//   - 注意：对 vector / deque，把整段 range 一次性插入通常比 inserter 一个一个插入更高效。
+
+#include <algorithm>
+#include <deque>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <sstream>
+#include <vector>
+
+int main() {
+    std::vector<int> src{1, 2, 3, 4, 5};
+
+    // 1) reverse_iterator —— ++ 实际是 --
+    std::cout << "reverse iterate vec : ";
+    for (auto it = src.rbegin(); it != src.rend(); ++it) {
+        std::cout << *it << ' ';
+    }
+    std::cout << '\n';
+
+    // base() 把反向迭代器转成正向迭代器
+    auto r = src.rbegin();
+    ++r;  // 反向第二个 → 正向倒数第二
+    std::cout << "rbegin().base() points one-past-end: " << (src.rbegin().base() == src.end())
+              << '\n';
+    std::cout << "after ++rbegin, base() points to    : " << *r.base() << '\n';
+
+    // 2) back_inserter —— *it = val 等价于 push_back(val)
+    std::vector<int> sink;
+    std::copy(src.begin(), src.end(), std::back_inserter(sink));
+    std::cout << "after back_inserter copy, sink.size = " << sink.size() << '\n';
+
+    // front_inserter —— 元素会被反序压入（因为每个 push_front 都是头插）
+    std::deque<int> dq;
+    std::copy(src.begin(), src.end(), std::front_inserter(dq));
+    std::cout << "after front_inserter copy, dq[0] = " << dq.front() << ", dq.back = " << dq.back()
+              << '\n';
+
+    // inserter —— 每次插入到指定位置之前
+    std::list<int> lst{10, 99};
+    std::copy(src.begin(), src.end(), std::inserter(lst, std::next(lst.begin())));
+    std::cout << "after inserter list  : ";
+    for (int v : lst) {
+        std::cout << v << ' ';
+    }
+    std::cout << '\n';
+
+    // 3) 流迭代器：ostream_iterator 配合 std::copy 打印
+    std::cout << "via ostream_iterator: ";
+    std::copy(src.begin(), src.end(), std::ostream_iterator<int>{std::cout, " "});
+    std::cout << '\n';
+
+    // istream_iterator：从字符串流读入直到流不可解析
+    std::istringstream iss{"7 8 9 oops"};
+    std::vector<int> read;
+    std::copy(std::istream_iterator<int>{iss}, std::istream_iterator<int>{},
+              std::back_inserter(read));
+    std::cout << "from istream_iterator (stops at 'oops'), read.size = " << read.size() << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/iterators_traits.cpp
+++ b/modules/05_containers_ranges_p1/demos/iterators_traits.cpp
@@ -1,0 +1,72 @@
+// 迭代器类别（concept）、迭代器特征（traits），以及通用算法
+// std::advance / std::next / std::prev / std::distance 的最小演示。
+//
+// 关键点：
+//   - C++20 起，迭代器要求由 concept 描述（input_iterator、forward_iterator、
+//     bidirectional_iterator、random_access_iterator、contiguous_iterator）；
+//     concept 失败时编译错误信息比旧式 SFINAE 友好得多。
+//   - std::advance 在非随机访问迭代器上需要逐次 ++/--，因此对 list 是 O(n)；
+//     对 vector 才是 O(1)。
+//   - 指针也是迭代器；C 风格数组 + std::begin/end 同样适用。
+
+#include <forward_list>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <type_traits>
+#include <vector>
+
+namespace {
+
+template <class It>
+constexpr const char* categoryName() {
+    if constexpr (std::contiguous_iterator<It>) {
+        return "contiguous";
+    } else if constexpr (std::random_access_iterator<It>) {
+        return "random_access";
+    } else if constexpr (std::bidirectional_iterator<It>) {
+        return "bidirectional";
+    } else if constexpr (std::forward_iterator<It>) {
+        return "forward";
+    } else if constexpr (std::input_iterator<It>) {
+        return "input";
+    } else {
+        return "(none)";
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::vector<int> vec{1, 2, 3, 4, 5};
+    std::list<int> lst{1, 2, 3, 4, 5};
+    std::forward_list<int> flist{1, 2, 3};
+    int arr[3]{10, 20, 30};  // C 风格数组：指针就是迭代器
+
+    std::cout << "vector<int>::iterator        -> " << categoryName<decltype(vec.begin())>()
+              << '\n';
+    std::cout << "list<int>::iterator          -> " << categoryName<decltype(lst.begin())>()
+              << '\n';
+    std::cout << "forward_list<int>::iterator  -> " << categoryName<decltype(flist.begin())>()
+              << '\n';
+    std::cout << "int*                         -> " << categoryName<int*>() << '\n';
+
+    // 迭代器特征：value_type / difference_type
+    using VecIt = std::vector<int>::iterator;
+    static_assert(std::is_same_v<std::iter_value_t<VecIt>, int>);
+    static_assert(std::is_same_v<std::iter_reference_t<VecIt>, int&>);
+
+    // std::advance / next / prev / distance
+    auto it = vec.begin();
+    std::advance(it, 2);  // 现在指向 3
+    std::cout << "advance(begin, 2) = " << *it << '\n';
+    std::cout << "next(begin, 4)    = " << *std::next(vec.begin(), 4) << '\n';
+    std::cout << "prev(end, 1)      = " << *std::prev(vec.end(), 1) << '\n';
+    std::cout << "distance(b, e)    = " << std::distance(vec.begin(), vec.end()) << '\n';
+
+    // C 风格数组：std::begin/end 推导出指针
+    std::cout << "std::begin(arr) is int*: "
+              << std::is_same_v<decltype(std::begin(arr)), int*> << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/map_idioms.cpp
+++ b/modules/05_containers_ranges_p1/demos/map_idioms.cpp
@@ -1,0 +1,79 @@
+// std::map 的常用习语：访问、插入、查找、节点提取。
+//
+// 关键点：
+//   - operator[] 在键不存在时会插入默认值；读取也可能"无中生有"，因此不能用于 const map。
+//   - 真正的"只查询"应使用 find / contains（C++20）/ count。
+//   - 插入失败时 insert / emplace 会保持原值，try_emplace 进一步避免构造未使用的 value。
+//   - insert_or_assign（C++17）在已存在时覆盖，是真正的"有则更新，无则插入"。
+//   - C++17 起，extract 可以把节点摘出来；node_handle 既可单独修改键/值，也能被 insert
+//     回任意同类型 map（甚至 multimap，反之亦然）。
+
+#include <iostream>
+#include <map>
+#include <string>
+
+namespace {
+
+void dump(const char* tag, const std::map<std::string, int>& m) {
+    std::cout << tag << ": ";
+    for (auto const& [k, v] : m) {
+        std::cout << k << '=' << v << ' ';
+    }
+    std::cout << '\n';
+}
+
+}  // namespace
+
+int main() {
+    std::map<std::string, int> scores;
+
+    // 1) operator[] 会插入默认值（值类型必须可默认构造）
+    ++scores["alice"];
+    ++scores["alice"];
+    ++scores["bob"];
+    dump("after op[]++   ", scores);
+
+    // 2) 真正的查询：find / contains
+    if (auto it = scores.find("alice"); it != scores.end()) {
+        std::cout << "alice = " << it->second << '\n';
+    }
+    std::cout << "contains carol? " << scores.contains("carol") << '\n';
+
+    // 3) insert vs insert_or_assign vs try_emplace
+    auto [it1, ok1] = scores.insert({"alice", 999});
+    std::cout << "insert(alice,999) ok=" << ok1 << " (键存在则失败，仍指向旧值=" << it1->second
+              << ")\n";
+
+    scores.insert_or_assign("alice", 999);
+    dump("after IOA      ", scores);
+
+    // try_emplace：键已存在时不会构造 value（这里只是 int，但若是 unique_ptr<Texture>
+    // 这种昂贵对象，try_emplace 比 emplace 更安全，因为构造可能很贵）
+    scores.try_emplace("dave", 50);
+    scores.try_emplace("alice", 0);  // 已存在 → 不构造 value
+    dump("after try_emplace", scores);
+
+    // 4) lower_bound / upper_bound / equal_range
+    std::map<int, std::string> tag{{1, "a"}, {3, "c"}, {5, "e"}, {7, "g"}};
+    auto lb = tag.lower_bound(3);  // *lb >= 3   → key=3
+    auto ub = tag.upper_bound(3);  // *ub  > 3   → key=5
+    std::cout << "lower_bound(3) -> key=" << lb->first << '\n';
+    std::cout << "upper_bound(3) -> key=" << ub->first << '\n';
+
+    // 5) 节点提取：把"alice"换成"alex"，无需移动 value
+    if (auto node = scores.extract("alice"); !node.empty()) {
+        node.key() = "alex";
+        scores.insert(std::move(node));
+    }
+    dump("after rename   ", scores);
+
+    // 6) 结构化绑定：遍历键值对的简洁写法
+    int total = 0;
+    for (auto const& [k, v] : scores) {
+        (void)k;
+        total += v;
+    }
+    std::cout << "score total = " << total << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/priority_queue_demo.cpp
+++ b/modules/05_containers_ranges_p1/demos/priority_queue_demo.cpp
@@ -1,0 +1,66 @@
+// 容器适配器：std::stack、std::queue、std::priority_queue。
+//
+// 关键点：
+//   - 适配器把已有顺序容器"伪装"成另一种数据结构，因此不暴露迭代器。
+//   - stack 默认底层为 deque；queue 同样默认 deque；priority_queue 默认 vector。
+//   - 当数据量很大或缓存关系明显时，stack 可以选择 vector 作为底层（缓存更好）。
+//   - priority_queue 默认是 max-heap；想得到 min-heap 必须显式传入 std::greater。
+//   - priority_queue 的构造函数把比较器放在第一个参数，这是它的特殊之处。
+
+#include <functional>
+#include <iostream>
+#include <queue>
+#include <stack>
+#include <vector>
+
+int main() {
+    // === stack 用 vector 作底层 ===
+    std::stack<int, std::vector<int>> s;
+    s.push(1);
+    s.push(2);
+    s.push(3);
+    std::cout << "stack top=" << s.top() << ", size=" << s.size() << '\n';
+    s.pop();
+    std::cout << "after pop, top=" << s.top() << '\n';
+
+    // === queue ===
+    std::queue<int> q;
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    std::cout << "queue front=" << q.front() << ", back=" << q.back() << '\n';
+    q.pop();
+    std::cout << "after pop, front=" << q.front() << '\n';
+
+    // === priority_queue 默认是 max-heap ===
+    std::priority_queue<int> max_heap;
+    for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
+        max_heap.push(x);
+    }
+    std::cout << "max-heap pop order: ";
+    while (!max_heap.empty()) {
+        std::cout << max_heap.top() << ' ';
+        max_heap.pop();
+    }
+    std::cout << '\n';
+
+    // === min-heap：第三个模板参数填 std::greater ===
+    std::priority_queue<int, std::vector<int>, std::greater<int>> min_heap;
+    for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
+        min_heap.push(x);
+    }
+    std::cout << "min-heap pop order: ";
+    while (!min_heap.empty()) {
+        std::cout << min_heap.top() << ' ';
+        min_heap.pop();
+    }
+    std::cout << '\n';
+
+    // === 由迭代器对构造（C++11 起，priority_queue 提供）===
+    // Floyd 建堆 O(n)，比逐个 push 的 O(n log n) 更便宜。
+    std::vector<int> data{8, 3, 7, 2, 9, 1};
+    std::priority_queue<int> built{std::less<int>{}, data};  // 拷贝构造底层容器并堆化
+    std::cout << "priority_queue built from vector, top=" << built.top() << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/span_view.cpp
+++ b/modules/05_containers_ranges_p1/demos/span_view.cpp
@@ -1,0 +1,61 @@
+// std::span：连续内存的非拥有视图（C++20）。
+//
+// 关键点：
+//   - span 只是"指针 + 长度"，构造与拷贝都很廉价；它不拥有数据。
+//   - 当你只想观察一段连续元素（不论它来自 vector / array / 原生数组），
+//     传 span<T> 比传引用 + size 或拷贝出新容器都好。
+//   - 来源容器一旦发生重分配（例如 vector 扩容），span 就悬空 —— 与裸指针一样不安全。
+//   - 静态 extent (`std::span<T, N>`) 把长度编入类型；只有 std::array 与 T[N]
+//     可以隐式转换得到。
+//   - C++26 之前 span 不做边界检查，越界访问 UB。
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <numeric>
+#include <span>
+#include <vector>
+
+namespace {
+
+// 函数形参写成 std::span，可以接受 vector / array / 原生数组 / initializer_list
+int sum(std::span<const int> s) {
+    return std::accumulate(s.begin(), s.end(), 0);
+}
+
+}  // namespace
+
+int main() {
+    std::vector<int> vec{1, 2, 3, 4, 5, 6};
+    std::array<int, 4> arr{10, 20, 30, 40};
+    int c_arr[3]{100, 200, 300};
+
+    std::cout << "sum(vec) = " << sum(vec) << '\n';
+    std::cout << "sum(arr) = " << sum(arr) << '\n';
+    std::cout << "sum(c_arr) = " << sum(c_arr) << '\n';
+
+    // 子 span：first / last / subspan
+    std::span<int> s{vec};
+    auto head3 = s.first(3);
+    auto tail2 = s.last(2);
+    auto mid = s.subspan(2, 3);  // 从下标 2 起、长 3
+    std::cout << "first(3) sum = " << sum(head3) << '\n';
+    std::cout << "last(2)  sum = " << sum(tail2) << '\n';
+    std::cout << "subspan(2,3) sum = " << sum(mid) << '\n';
+
+    // span 是非拥有视图：通过它修改会写回原 vector
+    s[0] = 999;
+    std::cout << "after s[0]=999, vec[0]=" << vec[0] << '\n';
+
+    // 静态 extent：编译期长度 → sizeof(span) 通常只有一个指针
+    std::span<int, 4> static_view{arr};
+    std::cout << "static extent = " << static_view.extent << ", dynamic_extent? "
+              << (static_view.extent == std::dynamic_extent) << '\n';
+
+    // 转字节视图：常用于二进制 IO
+    auto bytes = std::as_bytes(std::span{arr});
+    std::cout << "as_bytes size = " << bytes.size_bytes() << " (= " << arr.size() * sizeof(int)
+              << ")\n";
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/unordered_custom_hash.cpp
+++ b/modules/05_containers_ranges_p1/demos/unordered_custom_hash.cpp
@@ -1,0 +1,78 @@
+// std::unordered_map：自定义类型作为键时的两种哈希接入方式，以及桶层接口。
+//
+// 关键点：
+//   - unordered_map 需要 Hash + KeyEqual 两个仿函数。
+//   - 接入方式 A：定义一个带 operator() 的类型，作为模板参数显式传入。
+//   - 接入方式 B：特化 std::hash<MyType>，从而能像 std::string 一样直接当键用。
+//   - 负载因子（load_factor = size / bucket_count）超过 max_load_factor
+//     就会触发 rehash；rehash 会让所有迭代器失效（基于节点，引用仍有效）。
+//   - bucket_count() / bucket(key) / bucket_size(i) 提供了一窥哈希分布的接口。
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace {
+
+// 自定义聚合体作为键
+struct Point {
+    int x;
+    int y;
+    bool operator==(const Point&) const = default;
+};
+
+// 方式 A：仿函数
+struct PointHash {
+    std::size_t operator()(Point const& p) const noexcept {
+        // 朴素做法：异或；正经设计哈希函数请参考 Boost.hash_combine 等。
+        return std::hash<int>{}(p.x) ^ (std::hash<int>{}(p.y) << 1U);
+    }
+};
+
+}  // namespace
+
+// 方式 B：特化 std::hash —— 必须在命名空间 std 内
+template <>
+struct std::hash<Point> {
+    std::size_t operator()(Point const& p) const noexcept {
+        return std::hash<int>{}(p.x) * 31U + std::hash<int>{}(p.y);
+    }
+};
+
+int main() {
+    // 方式 A
+    std::unordered_set<Point, PointHash> via_functor;
+    via_functor.insert({1, 2});
+    via_functor.insert({3, 4});
+    std::cout << "via PointHash, size=" << via_functor.size() << '\n';
+
+    // 方式 B：直接用，无需显式传 Hash
+    std::unordered_map<Point, std::string> labels;
+    labels[{0, 0}] = "origin";
+    labels[{1, 1}] = "diag";
+    std::cout << "labels[{0,0}] = " << labels.at({0, 0}) << '\n';
+
+    // 负载因子与 reserve
+    std::unordered_map<int, int> table;
+    std::cout << "default max_load_factor = " << table.max_load_factor()
+              << ", initial bucket_count = " << table.bucket_count() << '\n';
+
+    // reserve(N) ≈ rehash(ceil(N / max_load_factor))，保证 N 之前不再 rehash
+    table.reserve(1000);
+    std::cout << "after reserve(1000), bucket_count = " << table.bucket_count() << '\n';
+
+    for (int i = 0; i < 64; ++i) {
+        table.emplace(i, i * i);
+    }
+    std::cout << "load_factor = " << table.load_factor() << '\n';
+
+    // 桶接口：观察某一桶中的元素
+    std::size_t bidx = table.bucket(7);
+    std::cout << "key 7 lives in bucket #" << bidx << ", bucket_size=" << table.bucket_size(bidx)
+              << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
+++ b/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
@@ -1,0 +1,49 @@
+// vector<bool> 的代理引用（proxy reference）陷阱。
+//
+// 关键点：
+//   - vector<bool> 是被压缩的位数组特化，operator[] 不能返回 bool&；
+//     它返回的是一个代理对象，可以读、可以赋值，但它本身不是普通引用。
+//   - 因此 `auto x = vb[i];` 推导出"代理"而非 bool，对它赋值会写回原 vector！
+//     这是与 vector<int> 完全不同的行为，新手很容易踩坑。
+//   - 相反，`auto& x = vb[i];` 不合法（代理是临时值，不能绑左值引用）。
+//   - 一般建议：要修改用 `auto`（保留代理），要只读用 `bool` 或 `const auto&`
+//     之外的方法（这里 `bool` 最稳）。
+//   - vector<bool> 的迭代器也不是 contiguous_iterator。
+
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+int main() {
+    std::vector<bool> vb{false, false, false};
+
+    // 对 vector<int> 而言 auto 推导出 int，赋值不影响容器
+    std::vector<int> vi{0, 0, 0};
+    {
+        auto x = vi[1];
+        x = 42;
+        std::cout << "vector<int>  vi[1]=" << vi[1] << " (auto 是值副本，写不回去)\n";
+    }
+
+    // 对 vector<bool>，auto 推导出代理；赋值"穿透"到位数组
+    {
+        auto bit = vb[1];  // 代理对象
+        bit = true;
+        std::cout << "vector<bool> vb[1]=" << vb[1] << " (auto 是代理，写回了)\n";
+    }
+
+    // 推导可视化：vb[i] 的类型不是 bool&
+    using BoolRef = decltype(vb[0]);
+    std::cout << "decltype(vb[0]) is bool& ? " << std::is_same_v<BoolRef, bool&> << '\n';
+
+    // 想"只读"，最稳的做法是写明 bool（强制拷贝出真值）
+    bool ro = vb[1];
+    ro = false;
+    std::cout << "after writing local bool, vb[1]=" << vb[1] << " (确实没改)\n";
+
+    // flip 翻转所有位，代理也支持 ~/flip()
+    vb.flip();
+    std::cout << "after flip(): vb={" << vb[0] << ',' << vb[1] << ',' << vb[2] << "}\n";
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/demos/vector_capacity.cpp
+++ b/modules/05_containers_ranges_p1/demos/vector_capacity.cpp
@@ -1,0 +1,79 @@
+// vector 的 size / capacity / 重分配观察。
+//
+// 关键点：
+//   - capacity 与 size 不同：capacity 是已分配的连续空间能容纳的元素数；
+//     size 是当前实际持有的元素数。
+//   - push_back 在 size == capacity 时触发重分配；多数实现按 1.5×（MS）或 2×
+//     （libstdc++）增长，从而保证摊还 O(1)。
+//   - reserve(n) 提前扩容到 capacity >= n，但不改变 size。提前 reserve 可以避免
+//     反复重分配，并在多线程持有迭代器/指针时避免悬空。
+//   - shrink_to_fit() 是请求，多数实现会照办，但不强制。
+//   - clear() 把 size 清零，但不释放容量。
+
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+void printState(const char* tag, const std::vector<int>& v) {
+    std::cout << tag << ": size=" << v.size() << ", capacity=" << v.capacity() << '\n';
+}
+
+}  // namespace
+
+int main() {
+    // 1) 默认构造的 vector 容量为 0
+    std::vector<int> v;
+    printState("default       ", v);
+
+    // 2) 连续 push_back，观察 capacity 跳变（标准未规定具体增长因子）
+    std::cout << "push_back 1..10 — capacity steps:\n";
+    std::size_t last_cap = v.capacity();
+    for (int i = 1; i <= 10; ++i) {
+        v.push_back(i);
+        if (v.capacity() != last_cap) {
+            std::cout << "  size=" << v.size() << ", capacity=" << v.capacity() << '\n';
+            last_cap = v.capacity();
+        }
+    }
+
+    // 3) reserve 一步到位，避免反复重分配
+    std::vector<int> w;
+    w.reserve(100);
+    printState("after reserve(100)", w);
+    for (int i = 0; i < 100; ++i) {
+        w.push_back(i);
+    }
+    printState("after 100 push_back", w);  // capacity 仍是 100
+
+    // 4) shrink_to_fit：把多余容量交回
+    v.shrink_to_fit();
+    printState("after shrink ", v);
+
+    // 5) clear 不释放容量
+    v.clear();
+    printState("after clear  ", v);
+
+    // 6) erase 返回下一个有效迭代器；可用于在循环中边删边遍历
+    std::vector<int> nums{1, 2, 3, 4, 5, 6};
+    for (auto it = nums.begin(); it != nums.end();) {
+        if (*it % 2 == 0) {
+            it = nums.erase(it);  // 不要写成 ++it，否则会跳过下一个元素
+        } else {
+            ++it;
+        }
+    }
+    std::cout << "after erase even: ";
+    for (int x : nums) {
+        std::cout << x << ' ';
+    }
+    std::cout << '\n';
+
+    // 7) C++20: std::erase / std::erase_if，O(n) 完成"删除全部相等元素"
+    std::vector<int> bag{1, 2, 3, 2, 1, 2};
+    auto removed = std::erase(bag, 2);
+    std::cout << "std::erase removed " << removed << " twos, now size=" << bag.size() << '\n';
+
+    return 0;
+}

--- a/modules/05_containers_ranges_p1/tests/test_adapters.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_adapters.cpp
@@ -1,0 +1,73 @@
+// 容器适配器：stack / queue / priority_queue。
+
+#include <functional>
+#include <queue>
+#include <stack>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(Stack, LIFO) {
+    std::stack<int> s;
+    s.push(1);
+    s.push(2);
+    s.push(3);
+    EXPECT_EQ(s.top(), 3);
+    s.pop();
+    EXPECT_EQ(s.top(), 2);
+    EXPECT_EQ(s.size(), 2U);
+}
+
+TEST(Stack, CustomUnderlyingContainer) {
+    // stack<int, vector<int>> 把 vector 作为底层容器：
+    // vector 缓存效率好；不像默认 deque 在小数据时常更慢。
+    std::stack<int, std::vector<int>> s;
+    s.push(1);
+    s.push(2);
+    EXPECT_EQ(s.top(), 2);
+}
+
+TEST(Queue, FIFO) {
+    std::queue<int> q;
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    EXPECT_EQ(q.front(), 1);
+    EXPECT_EQ(q.back(), 3);
+    q.pop();
+    EXPECT_EQ(q.front(), 2);
+}
+
+TEST(PriorityQueue, MaxHeapByDefault) {
+    std::priority_queue<int> pq;
+    for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
+        pq.push(x);
+    }
+    std::vector<int> out;
+    while (!pq.empty()) {
+        out.push_back(pq.top());
+        pq.pop();
+    }
+    EXPECT_EQ(out, (std::vector{9, 6, 5, 4, 3, 2, 1, 1}));
+}
+
+TEST(PriorityQueue, MinHeapWithGreater) {
+    std::priority_queue<int, std::vector<int>, std::greater<int>> pq;
+    for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
+        pq.push(x);
+    }
+    std::vector<int> out;
+    while (!pq.empty()) {
+        out.push_back(pq.top());
+        pq.pop();
+    }
+    EXPECT_EQ(out, (std::vector{1, 1, 2, 3, 4, 5, 6, 9}));
+}
+
+TEST(PriorityQueue, ConstructFromRangeBuildsHeapInLinearTime) {
+    // 通过迭代器对一次构造 → Floyd 建堆 O(n)
+    std::vector<int> data{8, 3, 7, 2, 9, 1};
+    std::priority_queue<int> pq{std::less<int>{}, data};
+    EXPECT_EQ(pq.top(), 9);
+    EXPECT_EQ(pq.size(), 6U);
+}

--- a/modules/05_containers_ranges_p1/tests/test_array.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_array.cpp
@@ -1,0 +1,56 @@
+// std::array：栈上固定大小数组的安全包装。
+
+#include <array>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+TEST(StdArray, SizeAndAccess) {
+    std::array<int, 4> a{10, 20, 30, 40};
+    EXPECT_EQ(a.size(), 4U);
+    EXPECT_FALSE(a.empty());
+    EXPECT_EQ(a.front(), 10);
+    EXPECT_EQ(a.back(), 40);
+    EXPECT_EQ(a[2], 30);
+}
+
+TEST(StdArray, AtChecksBounds) {
+    std::array<int, 3> a{1, 2, 3};
+    EXPECT_EQ(a.at(2), 3);
+    EXPECT_THROW(static_cast<void>(a.at(99)), std::out_of_range);
+}
+
+TEST(StdArray, FillAndSwap) {
+    std::array<int, 3> a{};
+    a.fill(7);
+    EXPECT_EQ(a, (std::array{7, 7, 7}));
+
+    std::array<int, 3> b{1, 2, 3};
+    a.swap(b);
+    EXPECT_EQ(a, (std::array{1, 2, 3}));
+    EXPECT_EQ(b, (std::array{7, 7, 7}));
+}
+
+TEST(StdArray, ComparisonIsLexicographic) {
+    std::array<int, 3> a{1, 2, 3};
+    std::array<int, 3> b{1, 2, 4};
+    EXPECT_LT(a, b);
+    EXPECT_NE(a, b);
+    EXPECT_EQ(a, (std::array{1, 2, 3}));
+}
+
+TEST(StdArray, ToArrayDeducesElementType) {
+    auto a = std::to_array({1, 2, 3, 4});  // C++20
+    static_assert(std::is_same_v<decltype(a), std::array<int, 4>>);
+    EXPECT_EQ(a.size(), 4U);
+    EXPECT_EQ(a[0], 1);
+}
+
+TEST(StdArray, StructuredBinding) {
+    std::array<int, 3> a{11, 22, 33};
+    auto& [x, y, z] = a;
+    x = 100;
+    EXPECT_EQ(a[0], 100);
+    EXPECT_EQ(y, 22);
+    EXPECT_EQ(z, 33);
+}

--- a/modules/05_containers_ranges_p1/tests/test_bitset.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_bitset.cpp
@@ -1,0 +1,64 @@
+// std::bitset：固定长度位串的运算与互转。
+
+#include <bitset>
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(Bitset, SizeAndIndexing) {
+    std::bitset<8> bs{0b1010'0110U};
+    EXPECT_EQ(bs.size(), 8U);
+    EXPECT_TRUE(bs[1]);
+    EXPECT_FALSE(bs[0]);
+    EXPECT_TRUE(bs[7]);
+}
+
+TEST(Bitset, SetResetFlip) {
+    std::bitset<4> bs;
+    bs.set();  // 全 1
+    EXPECT_TRUE(bs.all());
+    bs.reset(2);  // 位 2 → 0
+    EXPECT_FALSE(bs[2]);
+    bs.flip();  // 全部翻转
+    EXPECT_TRUE(bs[2]);
+    EXPECT_FALSE(bs[0]);
+}
+
+TEST(Bitset, CountAnyAllNone) {
+    std::bitset<8> bs{0b0010'0010U};
+    EXPECT_EQ(bs.count(), 2U);
+    EXPECT_TRUE(bs.any());
+    EXPECT_FALSE(bs.all());
+    EXPECT_FALSE(bs.none());
+
+    std::bitset<8> zero;
+    EXPECT_TRUE(zero.none());
+}
+
+TEST(Bitset, BitwiseOps) {
+    std::bitset<4> a{0b1100U};
+    std::bitset<4> b{0b1010U};
+    EXPECT_EQ((a & b).to_ulong(), 0b1000U);
+    EXPECT_EQ((a | b).to_ulong(), 0b1110U);
+    EXPECT_EQ((a ^ b).to_ulong(), 0b0110U);
+    EXPECT_EQ((~a).to_ulong(), 0b0011U);
+    EXPECT_EQ((a << 1).to_ulong(), 0b1000U);  // 高位被截掉
+    EXPECT_EQ((b >> 1).to_ulong(), 0b0101U);
+}
+
+TEST(Bitset, ConvertToString) {
+    std::bitset<5> bs{0b1'0110U};
+    EXPECT_EQ(bs.to_string(), "10110");
+    EXPECT_EQ(bs.to_string('o', 'x'), "xoxxo");
+}
+
+TEST(Bitset, TestThrowsOutOfRange) {
+    std::bitset<4> bs;
+    EXPECT_THROW(static_cast<void>(bs.test(99)), std::out_of_range);
+}
+
+TEST(Bitset, ConstructFromString) {
+    std::bitset<8> bs{std::string{"00001111"}};
+    EXPECT_EQ(bs.to_ulong(), 0b0000'1111U);
+}

--- a/modules/05_containers_ranges_p1/tests/test_iterators.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_iterators.cpp
@@ -1,0 +1,80 @@
+// 迭代器：concept 满足关系、traits、advance/distance、反向/插入/流迭代器。
+
+#include <forward_list>
+#include <iterator>
+#include <list>
+#include <sstream>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(IteratorConcepts, CategoriesMatchContainer) {
+    static_assert(std::contiguous_iterator<std::vector<int>::iterator>);
+    static_assert(std::random_access_iterator<std::vector<int>::iterator>);
+    static_assert(std::bidirectional_iterator<std::list<int>::iterator>);
+    static_assert(!std::random_access_iterator<std::list<int>::iterator>);
+    static_assert(std::forward_iterator<std::forward_list<int>::iterator>);
+    static_assert(!std::bidirectional_iterator<std::forward_list<int>::iterator>);
+
+    // 指针也是 contiguous 迭代器
+    static_assert(std::contiguous_iterator<int*>);
+}
+
+TEST(IteratorTraits, ValueAndReference) {
+    using It = std::vector<int>::iterator;
+    static_assert(std::is_same_v<std::iter_value_t<It>, int>);
+    static_assert(std::is_same_v<std::iter_reference_t<It>, int&>);
+    static_assert(std::is_same_v<std::iter_difference_t<It>, std::ptrdiff_t>);
+}
+
+TEST(IteratorOps, AdvanceAndDistance) {
+    std::list<int> lst{1, 2, 3, 4, 5};
+
+    auto it = lst.begin();
+    std::advance(it, 3);
+    EXPECT_EQ(*it, 4);
+
+    EXPECT_EQ(*std::next(lst.begin(), 2), 3);
+    EXPECT_EQ(*std::prev(lst.end(), 1), 5);
+
+    // 对非随机访问迭代器，distance 是 O(n) 但仍正确
+    EXPECT_EQ(std::distance(lst.begin(), lst.end()), 5);
+}
+
+TEST(ReverseIterator, BaseRelation) {
+    std::vector<int> v{1, 2, 3, 4};
+
+    EXPECT_EQ(v.rbegin().base(), v.end());
+    EXPECT_EQ(v.rend().base(), v.begin());
+
+    // ++rit 物理上等同 --base()
+    auto rit = v.rbegin();
+    ++rit;
+    EXPECT_EQ(*rit, 3);
+    EXPECT_EQ(*rit.base(), 4);  // base() 指向"当前所引用元素之后"
+}
+
+TEST(BackInserter, AppendsViaPushBack) {
+    std::vector<int> dst;
+    auto out = std::back_inserter(dst);
+    *out = 10;
+    *out = 20;
+    *out = 30;
+    EXPECT_EQ(dst, (std::vector{10, 20, 30}));
+}
+
+TEST(StreamIterator, ReadsUntilParseFails) {
+    std::istringstream iss{"1 2 3 stop 4"};
+    std::vector<int> got;
+    std::copy(std::istream_iterator<int>{iss}, std::istream_iterator<int>{},
+              std::back_inserter(got));
+    EXPECT_EQ(got, (std::vector{1, 2, 3}));
+}
+
+TEST(StreamIterator, OstreamIteratorWritesWithSeparator) {
+    std::ostringstream oss;
+    std::vector<int> v{1, 2, 3};
+    std::copy(v.begin(), v.end(), std::ostream_iterator<int>{oss, "-"});
+    EXPECT_EQ(oss.str(), "1-2-3-");
+}

--- a/modules/05_containers_ranges_p1/tests/test_map.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_map.cpp
@@ -1,0 +1,126 @@
+// std::map / set / multimap / multiset 与节点提取。
+
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+TEST(Map, OperatorBracketInsertsDefault) {
+    std::map<std::string, int> m;
+    int& v = m["new"];  // 默认插入 0
+    EXPECT_EQ(v, 0);
+    EXPECT_EQ(m.size(), 1U);
+    v = 7;
+    EXPECT_EQ(m["new"], 7);
+}
+
+TEST(Map, AtThrowsWhenMissing) {
+    std::map<std::string, int> m;
+    m["a"] = 1;
+    EXPECT_EQ(m.at("a"), 1);
+    EXPECT_THROW(static_cast<void>(m.at("missing")), std::out_of_range);
+}
+
+TEST(Map, FindAndContains) {
+    std::map<int, int> m{{1, 100}, {2, 200}};
+    auto it = m.find(2);
+    ASSERT_NE(it, m.end());
+    EXPECT_EQ(it->second, 200);
+
+    EXPECT_TRUE(m.contains(1));
+    EXPECT_FALSE(m.contains(99));
+    EXPECT_EQ(m.count(1), 1U);
+    EXPECT_EQ(m.count(99), 0U);
+}
+
+TEST(Map, InsertVsInsertOrAssignVsTryEmplace) {
+    std::map<std::string, int> m{{"a", 1}};
+
+    auto [it1, ok1] = m.insert({"a", 999});
+    EXPECT_FALSE(ok1);
+    EXPECT_EQ(it1->second, 1);  // 失败时保留旧值
+
+    auto [it2, ok2] = m.insert_or_assign("a", 999);
+    EXPECT_FALSE(ok2);  // 表示是 assign 而非 insert
+    EXPECT_EQ(it2->second, 999);
+
+    auto [it3, ok3] = m.try_emplace("b", 42);
+    EXPECT_TRUE(ok3);
+    EXPECT_EQ(it3->second, 42);
+}
+
+TEST(Map, LowerUpperBoundEqualRange) {
+    std::map<int, int> m{{1, 10}, {3, 30}, {5, 50}, {7, 70}};
+    EXPECT_EQ(m.lower_bound(3)->first, 3);
+    EXPECT_EQ(m.upper_bound(3)->first, 5);
+    EXPECT_EQ(m.lower_bound(4)->first, 5);  // 不存在 → 下一个更大键
+
+    auto [lo, hi] = m.equal_range(3);
+    EXPECT_EQ(lo->first, 3);
+    EXPECT_EQ(hi->first, 5);
+
+    auto [lo2, hi2] = m.equal_range(4);
+    EXPECT_EQ(lo2, hi2);  // 不存在的键：返回空区间
+}
+
+TEST(Map, ExtractAllowsKeyRename) {
+    std::map<std::string, int> m{{"alice", 1}, {"bob", 2}};
+    auto node = m.extract("alice");
+    ASSERT_FALSE(node.empty());
+    node.key() = "alex";
+    auto result = m.insert(std::move(node));
+    EXPECT_TRUE(result.inserted);
+    EXPECT_EQ(m.count("alice"), 0U);
+    EXPECT_EQ(m.at("alex"), 1);
+}
+
+TEST(Map, MergeOnlyMovesNonExisting) {
+    std::map<int, std::string> dst{{1, "old1"}, {2, "old2"}};
+    std::map<int, std::string> src{{2, "new2"}, {3, "new3"}};
+    dst.merge(src);
+    EXPECT_EQ(dst.size(), 3U);
+    EXPECT_EQ(dst.at(1), "old1");
+    EXPECT_EQ(dst.at(2), "old2");  // 已存在的键保留旧值
+    EXPECT_EQ(dst.at(3), "new3");
+    EXPECT_EQ(src.size(), 1U);  // src 中"无法移走"的留下
+    EXPECT_EQ(src.at(2), "new2");
+}
+
+TEST(Multimap, EqualRangeYieldsAllMatches) {
+    std::multimap<int, char> m{{1, 'a'}, {2, 'b'}, {2, 'c'}, {2, 'd'}, {3, 'e'}};
+    EXPECT_EQ(m.count(2), 3U);
+
+    auto [lo, hi] = m.equal_range(2);
+    int n = 0;
+    for (auto it = lo; it != hi; ++it, ++n) {
+        EXPECT_EQ(it->first, 2);
+    }
+    EXPECT_EQ(n, 3);
+}
+
+TEST(Set, BasicOps) {
+    std::set<int> s{3, 1, 4, 1, 5, 9, 2, 6};  // 自动去重 + 排序
+    EXPECT_EQ(s.size(), 7U);
+    EXPECT_TRUE(s.contains(1));
+    EXPECT_FALSE(s.contains(7));
+
+    // 顺序遍历得到升序
+    int prev = *s.begin();
+    for (auto it = std::next(s.begin()); it != s.end(); ++it) {
+        EXPECT_LT(prev, *it);
+        prev = *it;
+    }
+}
+
+TEST(Set, NodeExchangeWithMultiset) {
+    std::multiset<int> ms{1, 2, 2, 3};
+    std::set<int> s;
+    auto node = ms.extract(2);  // 取一个 2
+    ASSERT_FALSE(node.empty());
+    s.insert(std::move(node));  // 节点跨容器移动
+    EXPECT_EQ(s.size(), 1U);
+    EXPECT_TRUE(s.contains(2));
+}

--- a/modules/05_containers_ranges_p1/tests/test_sequence.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_sequence.cpp
@@ -1,0 +1,106 @@
+// 顺序容器（除 vector / array）：deque、list、forward_list 的关键 API。
+
+#include <deque>
+#include <forward_list>
+#include <list>
+
+#include <gtest/gtest.h>
+
+TEST(Deque, PushFrontAndBack) {
+    std::deque<int> d;
+    d.push_back(2);
+    d.push_back(3);
+    d.push_front(1);
+    d.push_front(0);
+    EXPECT_EQ(d.front(), 0);
+    EXPECT_EQ(d.back(), 3);
+    EXPECT_EQ(d.size(), 4U);
+    EXPECT_EQ(d[2], 2);  // 随机访问
+}
+
+TEST(Deque, ReferenceStableAcrossEndPushes) {
+    std::deque<int> d{1, 2, 3};
+    int& back_ref = d.back();
+    int* back_addr = &back_ref;
+    d.push_front(0);
+    d.push_front(-1);
+    // 端点 push 不会重定位已存在的元素（块本身不变）
+    EXPECT_EQ(back_addr, &d.back());
+    EXPECT_EQ(*back_addr, 3);
+}
+
+TEST(List, SpliceMovesNodes) {
+    std::list<int> a{1, 2};
+    std::list<int> b{10, 20, 30};
+    a.splice(a.end(), b);
+    EXPECT_EQ(a.size(), 5U);
+    EXPECT_EQ(b.size(), 0U);  // 节点已被移走
+    EXPECT_EQ(a, (std::list{1, 2, 10, 20, 30}));
+}
+
+TEST(List, SortIsStable) {
+    struct Item {
+        int key;
+        int idx;
+        bool operator==(const Item&) const = default;
+    };
+    std::list<Item> items{{2, 0}, {1, 1}, {2, 2}, {1, 3}};
+    items.sort([](Item const& l, Item const& r) { return l.key < r.key; });
+
+    auto it = items.begin();
+    EXPECT_EQ(it->idx, 1);  // key=1, idx=1
+    ++it;
+    EXPECT_EQ(it->idx, 3);  // key=1, idx=3 → 在 idx=1 之后（稳定）
+    ++it;
+    EXPECT_EQ(it->idx, 0);
+    ++it;
+    EXPECT_EQ(it->idx, 2);
+}
+
+TEST(List, UniqueAndRemoveIfReturnCount) {
+    std::list<int> nums{1, 1, 2, 3, 3, 3, 4};
+    auto removed = nums.unique();
+    EXPECT_EQ(removed, 3U);  // 去掉 3 个相邻重复
+    EXPECT_EQ(nums, (std::list{1, 2, 3, 4}));
+
+    auto removed_if = nums.remove_if([](int x) { return x % 2 == 0; });
+    EXPECT_EQ(removed_if, 2U);
+    EXPECT_EQ(nums, (std::list{1, 3}));
+}
+
+TEST(List, MergeOnSortedLists) {
+    std::list<int> a{1, 3, 5};
+    std::list<int> b{2, 4, 6};
+    a.merge(b);
+    EXPECT_EQ(a, (std::list{1, 2, 3, 4, 5, 6}));
+    EXPECT_EQ(b.size(), 0U);
+}
+
+TEST(ForwardList, BeforeBeginAndInsertAfter) {
+    std::forward_list<int> fl{2, 3, 4};
+    // 在头部之前插入：用 before_begin
+    fl.insert_after(fl.before_begin(), 1);
+    auto it = fl.begin();
+    EXPECT_EQ(*it, 1);
+    EXPECT_EQ(*++it, 2);
+}
+
+TEST(ForwardList, EraseAfter) {
+    std::forward_list<int> fl{1, 2, 3, 4};
+    auto it = fl.before_begin();
+    fl.erase_after(it);  // 删 1
+    EXPECT_EQ(fl.front(), 2);
+}
+
+TEST(ForwardList, SpliceAfter) {
+    std::forward_list<int> a{1, 2};
+    std::forward_list<int> b{10, 20};
+    auto a_first = a.begin();    // 指向 1
+    a.splice_after(a_first, b);  // 在 1 之后接入 b 的全部
+    auto it = a.begin();
+    EXPECT_EQ(*it++, 1);
+    EXPECT_EQ(*it++, 10);
+    EXPECT_EQ(*it++, 20);
+    EXPECT_EQ(*it++, 2);
+    EXPECT_TRUE(b.empty());
+}

--- a/modules/05_containers_ranges_p1/tests/test_span.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_span.cpp
@@ -1,0 +1,71 @@
+// std::span：连续视图的不变量。
+
+#include <array>
+#include <cstddef>
+#include <numeric>
+#include <span>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(Span, ConstructFromVector) {
+    std::vector<int> v{1, 2, 3, 4, 5};
+    std::span<int> s{v};
+    EXPECT_EQ(s.size(), 5U);
+    EXPECT_EQ(s.front(), 1);
+    EXPECT_EQ(s.back(), 5);
+    EXPECT_EQ(s.data(), v.data());
+}
+
+TEST(Span, FirstLastSubspan) {
+    std::array<int, 6> a{10, 20, 30, 40, 50, 60};
+    std::span<int> s{a};
+
+    auto head2 = s.first(2);
+    EXPECT_EQ(head2.size(), 2U);
+    EXPECT_EQ(head2.front(), 10);
+    EXPECT_EQ(head2.back(), 20);
+
+    auto tail3 = s.last(3);
+    EXPECT_EQ(tail3.size(), 3U);
+    EXPECT_EQ(tail3.front(), 40);
+
+    auto mid = s.subspan(1, 3);
+    EXPECT_EQ(mid.size(), 3U);
+    EXPECT_EQ(std::accumulate(mid.begin(), mid.end(), 0), 20 + 30 + 40);
+}
+
+TEST(Span, IsNonOwningView) {
+    std::vector<int> v{1, 2, 3};
+    std::span<int> s{v};
+    s[0] = 999;  // 通过 span 写入 → 写穿到原容器
+    EXPECT_EQ(v[0], 999);
+}
+
+TEST(Span, ConstSpanForReadOnly) {
+    std::vector<int> v{1, 2, 3};
+    std::span<const int> ro{v};
+    EXPECT_EQ(ro.size(), 3U);
+    // ro[0] = 0;          // 不会编译：const T*
+    EXPECT_EQ(ro.front(), 1);
+}
+
+TEST(Span, StaticVsDynamicExtent) {
+    std::array<int, 4> a{1, 2, 3, 4};
+
+    // 由 std::array 隐式得到固定 extent 的 span
+    std::span<int, 4> sa{a};
+    static_assert(decltype(sa)::extent == 4);
+
+    // 由 vector 得到的 span 是动态 extent
+    std::vector<int> v{1, 2};
+    std::span<int> sd{v};
+    static_assert(decltype(sd)::extent == std::dynamic_extent);
+    EXPECT_EQ(sd.size(), 2U);
+}
+
+TEST(Span, AsBytesSizeMatches) {
+    std::array<std::int32_t, 3> a{1, 2, 3};
+    auto bytes = std::as_bytes(std::span{a});
+    EXPECT_EQ(bytes.size_bytes(), sizeof(std::int32_t) * 3);
+}

--- a/modules/05_containers_ranges_p1/tests/test_tuple.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_tuple.cpp
@@ -1,0 +1,78 @@
+// std::tuple、std::pair 与结构化绑定。
+
+#include <array>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+TEST(Tuple, BasicAccess) {
+    std::tuple<int, double, std::string> t{1, 2.5, "three"};
+    EXPECT_EQ(std::get<0>(t), 1);
+    EXPECT_DOUBLE_EQ(std::get<1>(t), 2.5);
+    EXPECT_EQ(std::get<2>(t), "three");
+
+    // 类型唯一时，可按类型取
+    EXPECT_EQ(std::get<int>(t), 1);
+    EXPECT_EQ(std::get<std::string>(t), "three");
+
+    static_assert(std::tuple_size_v<decltype(t)> == 3);
+    static_assert(std::is_same_v<std::tuple_element_t<1, decltype(t)>, double>);
+}
+
+TEST(Tuple, StructuredBinding) {
+    auto t = std::tuple{1, 2.5, std::string{"x"}};
+    auto& [a, b, c] = t;
+    a = 10;
+    EXPECT_EQ(std::get<0>(t), 10);
+    EXPECT_DOUBLE_EQ(b, 2.5);
+    EXPECT_EQ(c, "x");
+}
+
+TEST(Tuple, TieAssignment) {
+    std::tuple<int, int, int> t{1, 2, 3};
+    int x = 0;
+    int z = 0;
+    std::tie(x, std::ignore, z) = t;
+    EXPECT_EQ(x, 1);
+    EXPECT_EQ(z, 3);
+}
+
+TEST(Tuple, TupleCat) {
+    auto a = std::tuple{1, 'a'};
+    auto b = std::tuple{2.5, std::string{"x"}};
+    auto c = std::tuple_cat(a, b);
+    static_assert(std::tuple_size_v<decltype(c)> == 4);
+    EXPECT_EQ(std::get<0>(c), 1);
+    EXPECT_EQ(std::get<3>(c), "x");
+}
+
+TEST(Pair, BehavesLikeTwoTuple) {
+    std::pair<int, std::string> p{42, "x"};
+    auto& [n, s] = p;
+    EXPECT_EQ(n, 42);
+    EXPECT_EQ(s, "x");
+    EXPECT_EQ(std::get<0>(p), 42);
+}
+
+TEST(Tuple, LexicographicComparison) {
+    std::tuple<int, int> a{1, 2};
+    std::tuple<int, int> b{1, 3};
+    EXPECT_LT(a, b);
+    EXPECT_NE(a, b);
+    EXPECT_EQ(a, (std::tuple{1, 2}));
+}
+
+TEST(Tuple, AggregateStructuredBinding) {
+    struct Point {
+        int x;
+        int y;
+    };
+    Point p{3, 4};
+    auto& [x, y] = p;
+    x = 30;
+    EXPECT_EQ(p.x, 30);
+    EXPECT_EQ(y, 4);
+}

--- a/modules/05_containers_ranges_p1/tests/test_unordered.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_unordered.cpp
@@ -1,0 +1,97 @@
+// std::unordered_map / set：负载因子、桶接口、自定义哈希。
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Point {
+    int x;
+    int y;
+    bool operator==(const Point&) const = default;
+};
+
+struct PointHash {
+    std::size_t operator()(Point const& p) const noexcept {
+        return std::hash<int>{}(p.x) ^ (std::hash<int>{}(p.y) << 1U);
+    }
+};
+
+}  // namespace
+
+TEST(UnorderedMap, BasicLookup) {
+    std::unordered_map<std::string, int> m;
+    m["a"] = 1;
+    m["b"] = 2;
+    EXPECT_EQ(m.at("a"), 1);
+    EXPECT_TRUE(m.contains("b"));
+    EXPECT_FALSE(m.contains("missing"));
+}
+
+TEST(UnorderedMap, LoadFactorAndReserve) {
+    std::unordered_map<int, int> m;
+    EXPECT_EQ(m.load_factor(), 0.0F);
+    EXPECT_GT(m.max_load_factor(), 0.0F);
+
+    m.reserve(1000);
+    EXPECT_GE(static_cast<float>(m.bucket_count()) * m.max_load_factor(), 1000.0F);
+
+    for (int i = 0; i < 64; ++i) {
+        m.emplace(i, i * 10);
+    }
+    EXPECT_LE(m.load_factor(), m.max_load_factor());
+}
+
+TEST(UnorderedMap, BucketInterface) {
+    std::unordered_map<int, int> m;
+    for (int i = 0; i < 32; ++i) {
+        m.emplace(i, i);
+    }
+    auto bidx = m.bucket(5);
+    EXPECT_LT(bidx, m.bucket_count());
+
+    // bucket_size = std::distance(begin(idx), end(idx))
+    auto count = std::distance(m.begin(bidx), m.end(bidx));
+    EXPECT_EQ(static_cast<std::size_t>(count), m.bucket_size(bidx));
+}
+
+TEST(UnorderedSet, CustomHashFunctor) {
+    std::unordered_set<Point, PointHash> s;
+    s.insert({1, 2});
+    s.insert({3, 4});
+    s.insert({1, 2});  // 重复 → 不插入
+    EXPECT_EQ(s.size(), 2U);
+    EXPECT_TRUE(s.contains(Point{1, 2}));
+}
+
+TEST(UnorderedMultimap, EqualityIgnoresOrderWithinKey) {
+    std::unordered_multimap<int, int> a;
+    a.emplace(1, 10);
+    a.emplace(1, 20);
+    a.emplace(2, 30);
+
+    std::unordered_multimap<int, int> b;
+    b.emplace(2, 30);
+    b.emplace(1, 20);
+    b.emplace(1, 10);
+
+    // 与 multimap 不同：unordered_multimap 的 == 只要每个键上的值集合互为排列即可。
+    EXPECT_EQ(a, b);
+}
+
+TEST(UnorderedMap, EraseByKeyAndIterator) {
+    std::unordered_map<int, int> m{{1, 10}, {2, 20}, {3, 30}};
+    EXPECT_EQ(m.erase(2), 1U);
+    EXPECT_EQ(m.size(), 2U);
+
+    auto it = m.find(1);
+    ASSERT_NE(it, m.end());
+    m.erase(it);
+    EXPECT_EQ(m.size(), 1U);
+}

--- a/modules/05_containers_ranges_p1/tests/test_vector.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_vector.cpp
@@ -1,0 +1,98 @@
+// std::vector：容量管理、迭代器/引用失效边界、erase 返回值、vector<bool> 代理。
+
+#include <iterator>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+TEST(Vector, ReserveDoesNotChangeSize) {
+    std::vector<int> v;
+    v.reserve(100);
+    EXPECT_EQ(v.size(), 0U);
+    EXPECT_GE(v.capacity(), 100U);
+}
+
+TEST(Vector, ClearKeepsCapacity) {
+    std::vector<int> v(50, 0);
+    auto cap_before = v.capacity();
+    v.clear();
+    EXPECT_EQ(v.size(), 0U);
+    EXPECT_EQ(v.capacity(), cap_before);  // 容量保留
+}
+
+TEST(Vector, ShrinkToFitDropsExtra) {
+    std::vector<int> v;
+    v.reserve(1024);
+    v.push_back(1);
+    EXPECT_GE(v.capacity(), 1024U);
+    v.shrink_to_fit();
+    // 主流实现都会真正收缩，但标准只规定为非绑定请求 → 用 LE 校验
+    EXPECT_LE(v.capacity(), 1024U);
+}
+
+TEST(Vector, IteratorsStableWhenReserveSufficient) {
+    std::vector<int> v;
+    v.reserve(8);
+    v.push_back(1);
+    int* p = &v.front();
+    v.push_back(2);
+    v.push_back(3);
+    EXPECT_EQ(p, &v.front());  // 没有重分配，引用仍有效
+}
+
+TEST(Vector, EraseReturnsNextValid) {
+    std::vector<int> v{1, 2, 3, 4, 5};
+    auto it = v.erase(v.begin() + 1);  // 删 2
+    EXPECT_EQ(*it, 3);
+    EXPECT_EQ(v, (std::vector{1, 3, 4, 5}));
+}
+
+TEST(Vector, InsertReturnsPositionOfFirstInserted) {
+    std::vector<int> v{1, 4};
+    auto it = v.insert(v.begin() + 1, {2, 3});
+    EXPECT_EQ(*it, 2);
+    EXPECT_EQ(v, (std::vector{1, 2, 3, 4}));
+}
+
+TEST(Vector, EmplaceBackReturnsReference) {
+    std::vector<int> v;
+    int& r = v.emplace_back(42);
+    EXPECT_EQ(&r, &v.back());
+    EXPECT_EQ(r, 42);
+}
+
+TEST(Vector, EraseAndEraseIfFreeFunctions) {
+    std::vector<int> v{1, 2, 3, 2, 1, 2};
+    auto removed = std::erase(v, 2);
+    EXPECT_EQ(removed, 3U);
+    EXPECT_EQ(v, (std::vector{1, 3, 1}));
+
+    std::vector<int> w{1, 2, 3, 4, 5};
+    auto removed_if = std::erase_if(w, [](int x) { return x % 2 == 0; });
+    EXPECT_EQ(removed_if, 2U);
+    EXPECT_EQ(w, (std::vector{1, 3, 5}));
+}
+
+TEST(Vector, AssignReplacesContent) {
+    std::vector<int> v{1, 2, 3};
+    v.assign(4, 7);
+    EXPECT_EQ(v, (std::vector{7, 7, 7, 7}));
+}
+
+TEST(VectorBool, ProxyAssignmentWritesThrough) {
+    std::vector<bool> vb(3, false);
+    auto bit = vb[1];  // 代理对象
+    bit = true;
+    EXPECT_TRUE(vb[1]);
+    EXPECT_FALSE(vb[0]);
+
+    vb.flip();
+    EXPECT_TRUE(vb[0]);
+    EXPECT_FALSE(vb[1]);
+}
+
+TEST(VectorBool, ProxyTypeIsNotBoolReference) {
+    std::vector<bool> vb(1, false);
+    using R = decltype(vb[0]);
+    static_assert(!std::is_same_v<R, bool&>);
+}


### PR DESCRIPTION
## Summary

- 新增模块 `05_containers_ranges_p1` 的完整 demo 与测试实现
- **10 个 demo**：迭代器 traits / 适配器、vector 容量 / `vector<bool>` 代理、`span`、`bitset`、deque / list、priority_queue、map 惯用法、unordered 自定义哈希
- **10 个 GTest 测试**：迭代器、array、vector、span、bitset、顺序容器、容器适配器、map / set、unordered_*、tuple / 结构化绑定
- 更新 `CMakeLists.txt`（注册全部 target）与 `README.md`（文档表格 + 运行指引）

## Test plan

- [ ] CI 9 路矩阵通过（gcc / clang / msvc / clang-cl / mingw / asan / conan / macos）
- [ ] `ctest --preset <p> -R 05_containers_ranges_p1` 全部 PASS
- [ ] lint job（clang-format + clang-tidy）通过

Made with [Cursor](https://cursor.com)