### PR TITLE
fix(05): 修复 clang-tidy 告警——静态成员访问、dead store、透明函子

### DIFF
--- a/modules/05_containers_ranges_p1/demos/iterator_adapters.cpp
+++ b/modules/05_containers_ranges_p1/demos/iterator_adapters.cpp
@@ -21,6 +21,9 @@ int main() {
 
     // 1) reverse_iterator —— ++ 实际是 --
     std::cout << "reverse iterate vec : ";
+    // 教学示例：本节重点演示 reverse_iterator 的传统迭代器写法，
+    // 故意保留显式 rbegin()/rend() 循环，不改成 range-based for。
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto it = src.rbegin(); it != src.rend(); ++it) {
         std::cout << *it << ' ';
     }

--- a/modules/05_containers_ranges_p1/demos/priority_queue_demo.cpp
+++ b/modules/05_containers_ranges_p1/demos/priority_queue_demo.cpp
@@ -45,7 +45,7 @@ int main() {
     std::cout << '\n';
 
     // === min-heap：第三个模板参数填 std::greater ===
-    std::priority_queue<int, std::vector<int>, std::greater<int>> min_heap;
+    std::priority_queue<int, std::vector<int>, std::greater<>> min_heap;
     for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
         min_heap.push(x);
     }

--- a/modules/05_containers_ranges_p1/demos/span_view.cpp
+++ b/modules/05_containers_ranges_p1/demos/span_view.cpp
@@ -49,8 +49,8 @@ int main() {
 
     // 静态 extent：编译期长度 → sizeof(span) 通常只有一个指针
     std::span<int, 4> static_view{arr};
-    constexpr auto ext = decltype(static_view)::extent;
-    std::cout << "static extent = " << ext << ", dynamic_extent? " << (ext == std::dynamic_extent)
+    constexpr auto kExt = decltype(static_view)::extent;
+    std::cout << "static extent = " << kExt << ", dynamic_extent? " << (kExt == std::dynamic_extent)
               << '\n';
 
     // 转字节视图：常用于二进制 IO

--- a/modules/05_containers_ranges_p1/demos/span_view.cpp
+++ b/modules/05_containers_ranges_p1/demos/span_view.cpp
@@ -49,8 +49,9 @@ int main() {
 
     // 静态 extent：编译期长度 → sizeof(span) 通常只有一个指针
     std::span<int, 4> static_view{arr};
-    std::cout << "static extent = " << static_view.extent << ", dynamic_extent? "
-              << (static_view.extent == std::dynamic_extent) << '\n';
+    constexpr auto ext = decltype(static_view)::extent;
+    std::cout << "static extent = " << ext << ", dynamic_extent? "
+              << (ext == std::dynamic_extent) << '\n';
 
     // 转字节视图：常用于二进制 IO
     auto bytes = std::as_bytes(std::span{arr});

--- a/modules/05_containers_ranges_p1/demos/span_view.cpp
+++ b/modules/05_containers_ranges_p1/demos/span_view.cpp
@@ -50,8 +50,8 @@ int main() {
     // 静态 extent：编译期长度 → sizeof(span) 通常只有一个指针
     std::span<int, 4> static_view{arr};
     constexpr auto ext = decltype(static_view)::extent;
-    std::cout << "static extent = " << ext << ", dynamic_extent? "
-              << (ext == std::dynamic_extent) << '\n';
+    std::cout << "static extent = " << ext << ", dynamic_extent? " << (ext == std::dynamic_extent)
+              << '\n';
 
     // 转字节视图：常用于二进制 IO
     auto bytes = std::as_bytes(std::span{arr});

--- a/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
+++ b/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
@@ -22,7 +22,8 @@ int main() {
     {
         auto x = vi[1];
         x = 42;
-        std::cout << "vector<int>  vi[1]=" << vi[1] << " (auto 是值副本，写不回去)\n";
+        std::cout << "vector<int>  x=" << x << ", vi[1]=" << vi[1]
+                  << " (auto 是值副本，写不回去)\n";
     }
 
     // 对 vector<bool>，auto 推导出代理；赋值"穿透"到位数组
@@ -39,7 +40,7 @@ int main() {
     // 想"只读"，最稳的做法是写明 bool（强制拷贝出真值）
     bool ro = vb[1];
     ro = false;
-    std::cout << "after writing local bool, vb[1]=" << vb[1] << " (确实没改)\n";
+    std::cout << "local bool ro=" << ro << ", vb[1]=" << vb[1] << " (确实没改)\n";
 
     // flip 翻转所有位，代理也支持 ~/flip()
     vb.flip();

--- a/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
+++ b/modules/05_containers_ranges_p1/demos/vector_bool_proxy.cpp
@@ -21,8 +21,9 @@ int main() {
     std::vector<int> vi{0, 0, 0};
     {
         auto x = vi[1];
+        std::cout << "vector<int>  init: x=" << x << " (copied from vi[1])\n";
         x = 42;
-        std::cout << "vector<int>  x=" << x << ", vi[1]=" << vi[1]
+        std::cout << "vector<int>  after x=42: x=" << x << ", vi[1]=" << vi[1]
                   << " (auto 是值副本，写不回去)\n";
     }
 
@@ -39,8 +40,9 @@ int main() {
 
     // 想"只读"，最稳的做法是写明 bool（强制拷贝出真值）
     bool ro = vb[1];
+    std::cout << "local bool init: ro=" << ro << " (copied from vb[1])\n";
     ro = false;
-    std::cout << "local bool ro=" << ro << ", vb[1]=" << vb[1] << " (确实没改)\n";
+    std::cout << "local bool after ro=false: ro=" << ro << ", vb[1]=" << vb[1] << " (vb 没改)\n";
 
     // flip 翻转所有位，代理也支持 ~/flip()
     vb.flip();

--- a/modules/05_containers_ranges_p1/tests/test_adapters.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_adapters.cpp
@@ -52,7 +52,7 @@ TEST(PriorityQueue, MaxHeapByDefault) {
 }
 
 TEST(PriorityQueue, MinHeapWithGreater) {
-    std::priority_queue<int, std::vector<int>, std::greater<int>> pq;
+    std::priority_queue<int, std::vector<int>, std::greater<>> pq;
     for (int x : {3, 1, 4, 1, 5, 9, 2, 6}) {
         pq.push(x);
     }


### PR DESCRIPTION
## Summary

- **span_view.cpp**: 用 `decltype(static_view)::extent` 替代通过实例访问静态成员 `extent`（`readability-static-accessed-through-instance`）
- **vector_bool_proxy.cpp**: 在 `std::cout` 中使用 `x` / `ro` 的值，消除 dead-store 告警（`clang-analyzer-deadcode.DeadStores`），同时保留教学意图
- **test_adapters.cpp**: `std::greater<int>` → `std::greater<>`（`modernize-use-transparent-functors`）

## Test plan

- [ ] CI lint job（clang-tidy）通过
- [ ] 全部 build/test 矩阵保持绿色

Made with [Cursor](https://cursor.com)