### PR TITLE
fix(cmake): clang-cl 警告分流改用 ${MSVC} 变量

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # （例如 <print>、std::expected、第二批 ranges）在当前的 MSVC 版本上只有用
 # /std:c++latest 才能启用。这里全局强制 latest，让用到这些较新库特性的 demo
 # 在 msvc preset 下也能编过。
-if(MSVC)
+#
+# 仅对真 cl.exe 注入：clang-cl 的 CMAKE_CXX_COMPILER_ID 是 "Clang" 而不是
+# "MSVC"，CMAKE_CXX_STANDARD=23 已经经由 -clang:-std=c++23 喂给 clang frontend，
+# 再追加 /std:c++latest 会被 clang-cl 视作 "argument unused" 并对每个 TU 刷一行
+# 警告。下面用 CXX_COMPILER_ID 把 clang-cl 排除掉。
+if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options(/std:c++latest)
 endif()
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -24,28 +24,43 @@ set(_mcpp_gnu_like_flags
     -Wformat=2
 )
 
+# cl.exe 与 clang-cl 都吃的 MSVC 风格 flag。
 set(_mcpp_msvc_flags
     /W4
     /permissive-
     /utf-8
     /Zc:__cplusplus
+)
+# 仅 cl.exe 才吃的 MSVC 独占 flag。clang-cl 默认就是符合标准的预处理器，
+# /Zc:preprocessor 在它那是 no-op 但会刷 -Wunused-command-line-argument，
+# 所以另列一组只给真 cl.exe。
+set(_mcpp_cl_only_flags
     /Zc:preprocessor
 )
 # 说明：/EHsc 是 MSVC 的默认异常模型 —— CMake 会自动把它注入到 C++ target，
 # 这里就不重复添加了。
 
-target_compile_options(mcpp_warnings INTERFACE
-    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:${_mcpp_gnu_like_flags}>
-    $<$<CXX_COMPILER_ID:MSVC>:${_mcpp_msvc_flags}>
-)
-
-target_compile_definitions(mcpp_warnings INTERFACE
-    $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX _CRT_SECURE_NO_WARNINGS>
-)
+# 用 ${MSVC} 而不是 $<CXX_COMPILER_ID:MSVC> 来分流：CMake 的 MSVC 变量对
+# cl.exe 与 clang-cl 都为 true，而 $<CXX_COMPILER_ID:MSVC> 只匹配 cl.exe。
+# 直接按 CXX_COMPILER_ID:Clang 把 clang-cl 划进 GNU-like 阵营会让它收到
+# -Wall（dash），clang-cl driver 把这条比 /Wall 还激进地展开（含
+# -Wc++98-compat、-Wpre-c++14-compat 整组兼容性提示），噪声很大。所以
+# clang-cl 走 MSVC 风格 flag 更稳。
+if(MSVC)
+    target_compile_options(mcpp_warnings INTERFACE ${_mcpp_msvc_flags})
+    target_compile_definitions(mcpp_warnings INTERFACE NOMINMAX _CRT_SECURE_NO_WARNINGS)
+    # 仅给真 cl.exe（clang-cl 的 CXX_COMPILER_ID 是 Clang）。
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(mcpp_warnings INTERFACE ${_mcpp_cl_only_flags})
+    endif()
+else()
+    target_compile_options(mcpp_warnings INTERFACE ${_mcpp_gnu_like_flags})
+endif()
 
 if(MCPP_WARNINGS_AS_ERRORS)
-    target_compile_options(mcpp_warnings INTERFACE
-        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>
-    )
+    if(MSVC)
+        target_compile_options(mcpp_warnings INTERFACE /WX)
+    else()
+        target_compile_options(mcpp_warnings INTERFACE -Werror)
+    endif()
 endif()


### PR DESCRIPTION
## Summary

- 把 `cmake/CompilerWarnings.cmake` 里 `$<CXX_COMPILER_ID:GNU,Clang,AppleClang>` 与 `$<CXX_COMPILER_ID:MSVC>` 的二分改成基于 `${MSVC}` 变量的二分。原写法把 clang-cl（`CXX_COMPILER_ID == Clang` 但 `MSVC == TRUE`）划进了 GNU-like 阵营，使它收到 `-Wall`（dash）——clang-cl driver 对 dash 形式的 `-Wall` 展开比 `/Wall` 还激进，会点亮 `-Wc++98-compat` / `-Wpre-c++14-compat` 整组兼容性警告（每个 TU 都刷一长串 "X is incompatible with C++98" 噪声）。
- `CMakeLists.txt` 顶层注入 `/std:c++latest` 同样收紧到真 cl.exe（`MSVC AND CXX_COMPILER_ID STREQUAL "MSVC"`）——clang-cl 已经从 `-clang:-std=c++23` 拿到了标准，再叠 `/std:c++latest` 会逐 TU 报 `unused-command-line-argument`。
- 把 `/Zc:preprocessor` 切出来只给真 cl.exe（clang-cl 上是 no-op 但会报 unused-arg）。
- 顺手让 `NOMINMAX` / `_CRT_SECURE_NO_WARNINGS` define 覆盖 clang-cl（之前只给 cl.exe，但 Windows ABI 下两者都该有，扩展是良性的）。
- `MCPP_WARNINGS_AS_ERRORS` 的 `-Werror` / `/WX` 分发也从 generator expression 改回简单 if/else，与新 `if(MSVC)` 块风格一致。

## 验证

本地 `clang-cl-relwithdebinfo` preset 全量 clean rebuild：
- 改前：每个用 C++11+ 特性的 TU 都刷 `-Wc++98-compat` 警告（实测 `attributes.cpp` 一个文件 10 条），外加每个 TU 一条 `'/std:c++latest' unused-command-line-argument`
- 改后：**0 warnings, 0 errors**

CI 矩阵覆盖此次改动的所有口径：
- `windows-msvc` / `windows-msvc-asan` 验真 cl.exe 仍能拿到 `/std:c++latest` + `/Zc:preprocessor`
- `windows-clang-cl` 验 clang-cl 走新分支
- `windows-mingw-gcc` 验 MinGW（`MSVC == FALSE`）仍走 GNU-like 分支
- `linux-gcc/clang/asan/conan`、`macos-clang` 验非 Windows 平台未受影响

## Test plan

- [ ] 全部 9 个 build/test job 保持绿
- [ ] lint job（clang-format + clang-tidy）保持绿