### PR TITLE
chore(clangd): 警告策略交回 compile_commands.json

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -20,13 +20,23 @@ CompileFlags:
   # IntelliSense 或装 LLVM 插件。
   CompilationDatabase: .
 
-  # 追加到所有编译命令的 flag，对 compile_commands.json 中已有的文件也生效
-  # 主要作用：保护「不在 DB 中的文件」（如临时新建的 .cpp）也能拿到正确的标准
+  # 追加到所有编译命令的 flag。它的合法用途是给「不在 DB 中的文件」
+  # （如刚 git pull 但还没 reconfigure 的 .cpp，或编辑器临时新建的草稿）兜底
+  # 一个正确的语言标准，而不是承担项目的警告策略。
+  #
+  # 历史上这里也写了 -Wall / -Wextra / -Wpedantic，但项目的警告策略已经由
+  # cmake/CompilerWarnings.cmake 按平台分流写进 compile_commands.json：
+  #   - Linux/macOS/MinGW（MSVC=FALSE）：_mcpp_gnu_like_flags，含 -Wall/-Wextra
+  #     /-Wpedantic/-Wshadow/-Wconversion 等
+  #   - Windows MSVC + clang-cl（MSVC=TRUE）：_mcpp_msvc_flags，走 /W4 /permissive-
+  #     /utf-8 /Zc:__cplusplus 这套
+  # 在 .clangd 里再 Add 一份 -Wall 等于双份覆盖，且因为 .clangd 平台无关，
+  # clang-cl driver 一旦看到 -Wall（dash）就会激进展开成 -Wc++98-compat /
+  # -Wpre-c++14-compat / -Wc++98-c++11-compat-binary-literal 等整族兼容性警告
+  # （项目目标 C++23，这一族纯噪声，且每出新标准还会冒新一批 -Wpre-c++NN-compat，
+  # 用 -Wno-* 抑制是打地鼠永无止境）。所以这里只兜底标准，警告交回 JSON。
   Add:
-    - -std=c++23 # C++23 标准（与项目主线一致）
-    - -Wall # 常用警告组
-    - -Wextra # 额外警告
-    - -Wpedantic # 严格 ISO 标准检查
+    - -std=c++23 # 只为不在 DB 中的文件兜底；DB 内文件由 cmake 写好的命令决定
 
   # 从 compile_commands.json 中剥离的 flag（支持 * 通配）
   # 主因：clang-cl + Ninja 生成的命令带 /Fo<obj> /Fd<dir>，clangd 改写命令后


### PR DESCRIPTION
## Summary

`.clangd` 里 `CompileFlags.Add` 历史上写了 `-Wall` / `-Wextra` / `-Wpedantic`，与 `cmake/CompilerWarnings.cmake` 写进 `compile_commands.json` 的内容重复覆盖。重复本身无害，但因为 `.clangd` 平台无关，clang-cl driver 一旦在 IDE 实时分析里收到 `-Wall`（dash）就会激进展开成 `-Wc++98-compat` / `-Wpre-c++14-compat` / `-Wc++98-c++11-compat-binary-literal` 等整族兼容性 hint，每个 TU 都刷一长串 "X is incompatible with C++98"。项目目标 C++23，这族噪声纯属无益，而且每出新标准还会冒新一批 `-Wpre-c++NN-compat`——用 `-Wno-*` 抑制是打地鼠永无止境。

正解是**让 `compile_commands.json` 一份说了算**（cmake 已经按平台分流写好了：Linux/MinGW 走 GNU-like，Windows MSVC + clang-cl 走 `/W4 /permissive-` 等 MSVC 风格），`.clangd` 只承担它真正合法的职责——给"不在 DB 中的临时文件"兜底语言标准。

## 关联 PR

跟 #21 一起看效果最佳：
- #21 修了 cmake 一侧（让 `compile_commands.json` 在 Windows clang-cl 上发出 MSVC 风格 flag 而不是 `-Wall`-dash）
- 本 PR 修 .clangd 一侧（去掉与 JSON 重复的警告 flag）

两者独立有效但相互加成：在 Windows clang-cl IDE 上要彻底无噪声，两者都需要。

## 改动细节

- **保留**：`Add: -std=c++23`（这是 `.clangd` 里 `Add` 的合法兜底用途）
- **删除**：`Add: -Wall / -Wextra / -Wpedantic`（已由 cmake 在 JSON 里按平台正确分流）
- **保持原样**：`Remove: /Fo* /Fd* /FS`（这是 clang-cl + Ninja 在 clangd-side 必须的剥离工作，无法迁移到 JSON）
- **更新注释**：把上述 rationale 写进 `.clangd` 的 inline comment，避免后续同类回归

## Test plan

- [ ] CI 全绿（仅文档/配置改动，不影响真编译；CI 矩阵的所有 build/test 应该不受影响）
- [ ] 本地在 Windows clang-cl preset 下打开 .cpp，clangd 实时分析不再产生 `-Wc++98-compat` 等兼容性 hint（前提：与 #21 同时生效）
- [ ] Linux GCC/Clang 一侧实时分析仍能看到 `-Wall -Wextra -Wpedantic` 类警告（来自 JSON）