### PR TITLE
feat(02): 生命周期/继承/类型安全 —— 13 个 demo + 11 个 GTest 测试

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,6 +38,14 @@
 #   portability-*        可移植性
 #   readability-*        可读性改进（命名、控制流复杂度、隐式 bool 转换）
 # -----------------------------------------------------------------------------
+# 注意：Checks 是 YAML folded scalar (`>`)，里面 `#` 不是注释 —— 它会被当成
+# 字符串的一部分，破坏 clang-tidy 对 Checks 的逗号分割解析（曾经把后面真正
+# 的 `-check-name` 一并废掉）。所以全部说明性注释保留在这块外面。
+#
+# 末尾这一批是 clang-tidy 21/22 新增 / 升 warning 级的检查，原本 master 用
+# clang-tidy 20 根本没启用过；统一关掉以保持检查面与历史一致。想开任何一条，
+# 要先把对应代码模式（v[i] 索引、聚合 init、static object 抛、main 抛、
+# `#if defined()` 等）逐处治理过再开。
 Checks: >
   bugprone-*,
   cert-*,
@@ -61,10 +69,6 @@ Checks: >
   -cert-err58-cpp,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -misc-non-private-member-variables-in-classes,
-  # ---- 下列检查在 clang-tidy 21/22 新增或被升级到 warning 级，原本 master
-  #      用 clang-tidy 20 时根本没启用过它们；统一关掉以保持检查面与历史一致。
-  #      想开任何一条，要先把对应代码模式（v[i] 索引、聚合 init、static
-  #      object 抛、main 抛、#if defined() 等）逐处治理过再开。
   -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -modernize-use-designated-initializers,
   -modernize-use-auto,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,18 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -cert-err58-cpp,
   -cppcoreguidelines-non-private-member-variables-in-classes,
-  -misc-non-private-member-variables-in-classes
+  -misc-non-private-member-variables-in-classes,
+  # ---- 下列检查在 clang-tidy 21/22 新增或被升级到 warning 级，原本 master
+  #      用 clang-tidy 20 时根本没启用过它们；统一关掉以保持检查面与历史一致。
+  #      想开任何一条，要先把对应代码模式（v[i] 索引、聚合 init、static
+  #      object 抛、main 抛、#if defined() 等）逐处治理过再开。
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -modernize-use-designated-initializers,
+  -modernize-use-auto,
+  -bugprone-throwing-static-initialization,
+  -bugprone-exception-escape,
+  -bugprone-derived-method-shadowing-base-method,
+  -readability-use-concise-preprocessor-directives
 
 
 # -----------------------------------------------------------------------------

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,13 +39,13 @@
 #   readability-*        可读性改进（命名、控制流复杂度、隐式 bool 转换）
 # -----------------------------------------------------------------------------
 # 注意：Checks 是 YAML folded scalar (`>`)，里面 `#` 不是注释 —— 它会被当成
-# 字符串的一部分，破坏 clang-tidy 对 Checks 的逗号分割解析（曾经把后面真正
-# 的 `-check-name` 一并废掉）。所以全部说明性注释保留在这块外面。
+# 字符串的一部分，破坏 clang-tidy 对 Checks 的逗号分割解析。所以说明性注释
+# 全部保留在这块外面。
 #
-# 末尾这一批是 clang-tidy 21/22 新增 / 升 warning 级的检查，原本 master 用
-# clang-tidy 20 根本没启用过；统一关掉以保持检查面与历史一致。想开任何一条，
-# 要先把对应代码模式（v[i] 索引、聚合 init、static object 抛、main 抛、
-# `#if defined()` 等）逐处治理过再开。
+# 仍禁用的 `pro-bounds-avoid-unchecked-container-access` 是 clang-tidy 21
+# 新增的，命中 `v[i]` / `bitset[i]` 等容器无界访问，全项目散落 60+ 处跨
+# module 02/05/06；这条单独留个 PR 治理（要么 .at(i)、要么显式 assert
+# bounds、要么本地 NOLINT），本 PR 不开。
 Checks: >
   bugprone-*,
   cert-*,
@@ -69,13 +69,7 @@ Checks: >
   -cert-err58-cpp,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -misc-non-private-member-variables-in-classes,
-  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
-  -modernize-use-designated-initializers,
-  -modernize-use-auto,
-  -bugprone-throwing-static-initialization,
-  -bugprone-exception-escape,
-  -bugprone-derived-method-shadowing-base-method,
-  -readability-use-concise-preprocessor-directives
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access
 
 
 # -----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,11 @@ jobs:
         if: matrix.uses-conan
         run: |
           pip install --upgrade --break-system-packages conan
-          # Default profile is required as Conan's --profile:build (used to
-          # compile build-tools), even when --profile:host points at a vendored
-          # profile under conan/profiles/. detect --force initialises it from
-          # whatever compiler is on PATH; that's fine because matrix.cc/.cxx
-          # are exported into the env below.
-          conan profile detect --force
+          # 不再调 `conan profile detect` —— 它把 default profile 写成宿主当前
+          # 编译器（在 Arch 上是 GCC 16），而 conan 2.28.1 settings.yml 最高
+          # 只承认到 15.2 → "Invalid setting '16'". 后续 install 用
+          # --profile:all 把 host + build profile 同时指向 conan/profiles/...，
+          # 完全绕开 default profile，所以 detect 这步可以省。
 
       - name: Conan install
         if: matrix.uses-conan
@@ -227,8 +226,10 @@ jobs:
           CC:  ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
         run: |
+          # --profile:all 同时设 host & build profile —— 避免 build profile
+          # fallback 到 default（detect 写的、可能含 conan 还不认识的版本号）。
           conan install . \
-            --profile:host=./conan/profiles/${{ matrix.conan-profile }} \
+            --profile:all=./conan/profiles/${{ matrix.conan-profile }} \
             --output-folder=build/${{ matrix.preset }} \
             --build=missing \
             -s build_type=${{ matrix.build-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,11 @@ jobs:
   lint:
     name: clang-format + clang-tidy
     runs-on: ubuntu-24.04
-    container: ubuntu:25.10
+    # Arch（rolling release）容器：clang-format / clang-tidy 始终跟 LLVM 上游
+    # 对齐（当前是 22.x），与 scoop / Homebrew / Arch 本地的 LLVM 版本一致，
+    # 避免本地 fmt 完 push 上来 CI 还报 format 不一致的版本错配。代价是：
+    # LLVM 升大版本时偶尔需要跟着 reformat 一遍 —— 通常每年一两次的事。
+    container: archlinux:base-devel
     env:
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
@@ -349,39 +353,29 @@ jobs:
 
       # 关键：在 actions/checkout 之前先装 git，否则 checkout 走 REST API
       # 不带 .git 目录，`format` / `tidy` target 的 `EXISTS .git` 守卫失败
-      # 会导致 target 静默不注册。
-      - name: Pre-install git (Linux container)
+      # 会导致 target 静默不注册。Arch 镜像 base-devel 已含 base-devel group，
+      # 但默认不带 git / ca-certificates —— 单独装一遍。
+      - name: Pre-install git (Arch container)
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            git ca-certificates
+          pacman -Sy --noconfirm --needed git ca-certificates
 
       - uses: actions/checkout@v4
 
       # 同 build-test：注册 workspace 为 safe.directory，否则容器 root 跑
       # `git ls-files`（format/tidy 都依赖）会被 dubious ownership 拒绝。
-      - name: Mark workspace as git safe.directory (Linux container)
+      - name: Mark workspace as git safe.directory (Arch container)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      # The lint job uses the clang-relwithdebinfo preset on purpose: clang-20
-      # together with libstdc++ from g++-15 sees the full C++23 stdlib surface
-      # (std::expected, std::generator, ranges::to, etc.), so try_compile
-      # guards in the modules don't skip targets out of compile_commands.json
-      # — that keeps clang-tidy's input set complete.
-      - name: Install toolchain (clang-20, g++-15, cmake, ninja, clang-format-20, clang-tidy-20)
+      # Arch 的 clang 包同时提供 clang-format / clang-tidy / clangd（与 Ubuntu
+      # 拆成多个 -NN 子包不同），全部走无版本名 —— 与 _clang preset 里
+      # CMAKE_C_COMPILER=clang 完全一致，无需 update-alternatives。base-devel
+      # 已带 gcc + libstdc++（提供 C++23 STL 头给 clang-tidy 编译时查找）。
+      - name: Install toolchain (Arch — clang/clang-format/clang-tidy + cmake/ninja)
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            clang-20 lld-20 g++-15 cmake ninja-build make \
-            clang-format-20 clang-tidy-20 \
-            git curl zip unzip tar pkg-config ca-certificates
-          # 同 build-test job：CMakePresets 里的 _clang preset 用无版本名，
-          # 必须建 alternatives 让 PATH 上的 clang/clang++ 指向 clang-20。
-          # gcc/g++ 也建一份（lint 跑 vcpkg/cmake 时 try_compile 仍需要）。
-          update-alternatives --install /usr/bin/gcc      gcc      /usr/bin/gcc-15      100
-          update-alternatives --install /usr/bin/g++      g++      /usr/bin/g++-15      100
-          update-alternatives --install /usr/bin/clang    clang    /usr/bin/clang-20    100
-          update-alternatives --install /usr/bin/clang++  clang++  /usr/bin/clang++-20  100
+          pacman -Sy --noconfirm --needed \
+            clang lld llvm \
+            cmake ninja make \
+            curl zip unzip tar pkgconf
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -393,8 +387,8 @@ jobs:
       # any compiled targets to lint, so go straight to the lint targets.
       - name: Configure
         env:
-          CC:  clang-20
-          CXX: clang++-20
+          CC:  clang
+          CXX: clang++
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         run: cmake --preset clang-relwithdebinfo
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,11 @@ jobs:
   build-test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    # Linux jobs run inside an ubuntu:25.10 container so the matrix gets
-    # GCC 15 / Clang 20 from the distro's default apt repos. The host
-    # runner stays ubuntu-24.04 (24.04 LTS apt only ships GCC 13 / Clang 18,
-    # which is too old for the C++23 ranges/generator API surface this
-    # repo demos). 25.10 (questing) is an interim release; the only thing
-    # CI needs from it is a recent libstdc++ + clang, so the 9-month
-    # support window is fine for the runner-side container.
+    # Linux jobs run inside an archlinux:base-devel container so the matrix
+    # tracks LLVM/GCC 上游（rolling release，当前 GCC 15.x / Clang 22.x），
+    # 与本地 scoop / Homebrew / Arch 的版本一致 —— 减少 lint/format 与本地的
+    # 版本错配。host runner 保持 ubuntu-24.04（容器里跑实际工具链就行）。
+    # base-devel 镜像已自带 base-devel group（gcc + make 等）。
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
@@ -30,26 +28,26 @@ jobs:
         include:
           - name: linux-gcc
             os: ubuntu-24.04
-            container: ubuntu:25.10
+            container: archlinux:base-devel
             preset: gcc-relwithdebinfo
-            cc: gcc-15
-            cxx: g++-15
+            cc: gcc
+            cxx: g++
 
           - name: linux-clang
             os: ubuntu-24.04
-            container: ubuntu:25.10
+            container: archlinux:base-devel
             preset: clang-relwithdebinfo
-            cc: clang-20
-            cxx: clang++-20
+            cc: clang
+            cxx: clang++
 
           # Sanitizer job: Debug + ASan/UBSan via MCPP_ENABLE_SANITIZERS.
           # Catches memory / UB regressions that release-mode jobs miss.
           - name: linux-gcc-asan
             os: ubuntu-24.04
-            container: ubuntu:25.10
+            container: archlinux:base-devel
             preset: gcc-debug
-            cc: gcc-15
-            cxx: g++-15
+            cc: gcc
+            cxx: g++
             extra-config: -DMCPP_ENABLE_SANITIZERS=ON
 
           # Conan path. Must pass `-s build_type=` matching the preset's
@@ -58,10 +56,10 @@ jobs:
           # empty at build time. cmake/Dependencies.cmake catches this.
           - name: linux-gcc-conan
             os: ubuntu-24.04
-            container: ubuntu:25.10
+            container: archlinux:base-devel
             preset: gcc-relwithdebinfo-conan
-            cc: gcc-15
-            cxx: g++-15
+            cc: gcc
+            cxx: g++
             uses-conan: true
             conan-profile: linux-gcc
             build-type: RelWithDebInfo
@@ -125,13 +123,11 @@ jobs:
       # actions/checkout 在容器里跑：若 PATH 上没有 git，它会走 REST API
       # fallback 拉 tarball（没有 .git 目录）。`format` / `tidy` target 用
       # `EXISTS ${CMAKE_SOURCE_DIR}/.git` 守卫，缺 .git 会让 target 静默
-      # 不注册。先单独装一遍 git + ca-certificates，让 checkout 走原生 git 路径。
-      - name: Pre-install git (Linux container)
+      # 不注册。Arch base-devel 镜像不含 git —— 单独 pacman 装一份。
+      - name: Pre-install git (Arch container)
         if: runner.os == 'Linux'
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            git ca-certificates
+          pacman -Sy --noconfirm --needed git ca-certificates
 
       - uses: actions/checkout@v4
 
@@ -145,33 +141,24 @@ jobs:
 
       # ------------------------------------------------------------------
       # Toolchain
-      #   Linux  — apt-install GCC/Clang inside the ubuntu:25.10 container
-      #            (running as root, so no sudo). Each Linux matrix entry
-      #            installs the same superset (g++-15 + clang-20 + ninja +
-      #            ccache + vcpkg/conan deps) so this step is reused. The
-      #            preset and matrix.cc/cxx pick which compiler is invoked.
+      #   Linux  — pacman-install GCC/Clang inside the archlinux:base-devel
+      #            container (running as root, so no sudo). 每个 Linux
+      #            matrix 入口都装同一套超集（gcc + clang + lld + ninja +
+      #            ccache + vcpkg/conan deps）。Arch 的 gcc/clang/clang-format
+      #            /clang-tidy/python 都是无版本名 —— 与 _gcc / _clang preset
+      #            的 CMAKE_C_COMPILER=gcc / clang 直接对得上，不需要
+      #            update-alternatives。
       #   Windows — rely on VS dev cmd (or MSYS2 for the MinGW job)
       #   macOS  — Apple Clang ships preinstalled, install Ninja via brew
       # ------------------------------------------------------------------
-      - name: Install toolchain (Linux container)
+      - name: Install toolchain (Arch container)
         if: runner.os == 'Linux'
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            g++-15 \
-            clang-20 lld-20 \
-            cmake ninja-build make ccache \
-            git curl zip unzip tar pkg-config ca-certificates \
-            python3 python3-pip
-          # apt 上的版本化包（g++-15 / clang-20 等）只装版本化二进制，
-          # 不创建无版本号的 /usr/bin/{gcc,g++,clang,clang++} 符号链接。
-          # CMakePresets.json 里的 _gcc / _clang preset 写的是无版本名，
-          # 且 cacheVariables 优先级高于 CC/CXX 环境变量 —— 所以在容器里
-          # 必须自己用 update-alternatives 把无版本名指向具体版本。
-          update-alternatives --install /usr/bin/gcc      gcc      /usr/bin/gcc-15      100
-          update-alternatives --install /usr/bin/g++      g++      /usr/bin/g++-15      100
-          update-alternatives --install /usr/bin/clang    clang    /usr/bin/clang-20    100
-          update-alternatives --install /usr/bin/clang++  clang++  /usr/bin/clang++-20  100
+          pacman -Sy --noconfirm --needed \
+            gcc clang lld llvm \
+            cmake ninja make ccache \
+            curl zip unzip tar pkgconf \
+            python python-pip
 
       - name: Install Ninja (macOS)
         if: runner.os == 'macOS'
@@ -370,12 +357,15 @@ jobs:
       # 拆成多个 -NN 子包不同），全部走无版本名 —— 与 _clang preset 里
       # CMAKE_C_COMPILER=clang 完全一致，无需 update-alternatives。base-devel
       # 已带 gcc + libstdc++（提供 C++23 STL 头给 clang-tidy 编译时查找）。
+      # python：run-clang-tidy 是 Python 脚本，缺 python 会导致 tidy-check 报
+      # `env: 'python3': No such file or directory`。
       - name: Install toolchain (Arch — clang/clang-format/clang-tidy + cmake/ninja)
         run: |
           pacman -Sy --noconfirm --needed \
             clang lld llvm \
             cmake ninja make \
-            curl zip unzip tar pkgconf
+            curl zip unzip tar pkgconf \
+            python
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,10 @@ job + 一个聚合门禁 job：
   - `windows-msvc`、`windows-clang-cl`、`windows-msvc-asan`、
     `windows-mingw-gcc`（MSYS2 UCRT64）
   - `macos-clang`（Apple Clang，验证 `clang-*` preset 的 Darwin 分支）
-- **lint** job：`clang-format-20 --dry-run --Werror`（`format-check` target）+
-  `clang-tidy-20`（`tidy-check` target），都跑在 `clang-relwithdebinfo` configure
-  之上。Linux jobs 在 `ubuntu:25.10` 容器里跑，apt 默认仓库提供 g++-15 / clang-20。
+- **lint** job：`clang-format --dry-run --Werror`（`format-check` target）+
+  `clang-tidy`（`tidy-check` target），都跑在 `clang-relwithdebinfo` configure
+  之上。Linux jobs 在 `archlinux:base-devel` 容器里跑，pacman 滚动提供 GCC / Clang
+  / clang-format / clang-tidy（当前 GCC 15.x、Clang 22.x，与本地 LLVM 22+ 一致）。
 - **required-ci** 聚合门禁：`needs: [build-test, lint]` + `if: always()`，把整个
   矩阵的成功/失败汇总成单一稳定状态，分支保护规则只需 require 这一个就够。
 
@@ -119,3 +120,28 @@ Conan 路径不走 vcpkg cache。完整指南见 `docs/ci-guide.md`。
 - 标识符（变量名、函数名、target 名等）仍保持英文，以匹配 `.clang-tidy` 规则。
 - 文档文件（`*.md`）保留中英双语版本（`docs/zh-CN.md` / `docs/en-US.md`）的现有规则不变。
 - 引用标准库术语、错误信息、第三方接口名时可保留原文（例如 `std::expected`、`gtest_discover_tests`），但围绕它们的解释用中文
+
+## 提交流程（针对 C++ 源文件改动）
+
+CI 的 lint job 用 `archlinux:base-devel` 容器里 pacman 滚动的 clang-format / clang-tidy
+（当前 LLVM 22.x）跑 `--target format-check` + `--target tidy-check`，且 clang-tidy 用
+`--warnings-as-errors=*` —— 任何 warning 都会让 PR 红。**修改 `modules/**/*.cpp` 或
+`modules/**/*.h*` 后，commit 之前必须本地依次跑下面三条命令，全部 exit 0 才提交**：
+
+```bash
+cmake --build --preset <你的 preset> --target format        # in-place 修复
+cmake --build --preset <你的 preset> --target format-check  # 复核
+cmake --build --preset <你的 preset> --target tidy-check    # 静态检查
+```
+
+为了让本地 clang-format / clang-tidy 输出与 CI 一致：
+- Windows：`scoop install llvm@22.1.4`（或更高 22.x patch）
+- macOS：`brew install llvm@22`
+- Linux：用 Arch / Tumbleweed 等滚动发行版；或 apt.llvm.org 装 22
+
+低于 22 的版本会出现"本地通过 / CI 失败"的版本错配（默认值随 LLVM 大版本会变 ——
+如 `IndentPPDirectives`、`AlignTrailingComments`，以及 21+ 新增的 lint check）。
+
+**不需要跑这一套的场景**：只改文档（`*.md`）/ CI yml / CMakeLists / .clang-* 配置时
+（这些都不在 format-check / tidy-check 的输入集里）—— 但如果同时改了 `.clang-format`
+/ `.clang-tidy`，记得仍要跑一遍 check 验证规则没把现有代码变红。

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -177,16 +177,16 @@ strategy:
   fail-fast: false
   matrix:
     include:
-      - { name: linux-gcc,         os: ubuntu-24.04, container: ubuntu:25.10,
-          preset: gcc-relwithdebinfo,    cc: gcc-15,   cxx: g++-15   }
-      - { name: linux-clang,       os: ubuntu-24.04, container: ubuntu:25.10,
-          preset: clang-relwithdebinfo,  cc: clang-20, cxx: clang++-20 }
-      - { name: linux-gcc-asan,    os: ubuntu-24.04, container: ubuntu:25.10,
-          preset: gcc-debug,             cc: gcc-15,   cxx: g++-15,
+      - { name: linux-gcc,         os: ubuntu-24.04, container: archlinux:base-devel,
+          preset: gcc-relwithdebinfo,    cc: gcc,   cxx: g++   }
+      - { name: linux-clang,       os: ubuntu-24.04, container: archlinux:base-devel,
+          preset: clang-relwithdebinfo,  cc: clang, cxx: clang++ }
+      - { name: linux-gcc-asan,    os: ubuntu-24.04, container: archlinux:base-devel,
+          preset: gcc-debug,             cc: gcc,   cxx: g++,
           extra-config: -DMCPP_ENABLE_SANITIZERS=ON }
-      - { name: linux-gcc-conan,   os: ubuntu-24.04, container: ubuntu:25.10,
+      - { name: linux-gcc-conan,   os: ubuntu-24.04, container: archlinux:base-devel,
           preset: gcc-relwithdebinfo-conan,
-          cc: gcc-15, cxx: g++-15, uses-conan: true,
+          cc: gcc, cxx: g++, uses-conan: true,
           conan-profile: linux-gcc, build-type: RelWithDebInfo }
       - { name: windows-msvc,      os: windows-2022, preset: msvc,
           build-preset: msvc-relwithdebinfo, test-preset: msvc-relwithdebinfo }
@@ -202,14 +202,19 @@ strategy:
           cc: clang, cxx: clang++ }
 ```
 
-> **为什么 Linux jobs 走 `container: ubuntu:25.10`？**
+> **为什么 Linux jobs 走 `container: archlinux:base-devel`？**
 > Ubuntu 24.04 LTS 默认 apt 仓库锁在 GCC 13 / Clang 18，但本仓库部分模块用到的
 > C++23 ranges/generator API（`std::ranges::to`、`<generator>`、`views::chunk` /
-> `zip` / `stride` / `cartesian_product` 等）需要 GCC 15 / libstdc++-15、Clang 20。
-> 升 Ubuntu 24.04 host runner 不可行（GitHub-hosted runners 一年内不会升 25.10），
-> 所以 Linux 4 路全部跑在 `ubuntu:25.10` 容器中——容器里 apt 默认仓库就有 g++-15、
-> clang-20、clang-format-20、clang-tidy-20，无需 ppa / LLVM 第三方仓库。host
-> 仍是 `ubuntu-24.04` 因为 GitHub 不直接提供 25.10 runner。Windows / macOS 不走容器。
+> `zip` / `stride` / `cartesian_product` 等）需要 GCC 15+ / libstdc++ 15+、Clang 20+。
+> 升 Ubuntu 24.04 host runner 不可行（GitHub-hosted runners 不主动跟最新非 LTS 版本），
+> 所以 Linux 4 路全部跑在 `archlinux:base-devel` 容器中——Arch 是滚动发行版，
+> pacman 默认仓库的 gcc / clang / clang-format / clang-tidy 始终跟 LLVM/GCC
+> 上游对齐（当前 GCC 15.x / Clang 22.x），与本地 scoop / Homebrew / Arch 的版本
+> 一致，**避免「本地 format/tidy 通过、CI 失败」的版本错配**。host 仍是
+> `ubuntu-24.04` 因为 GitHub 不直接提供 Arch runner。Windows / macOS 不走容器。
+>
+> 折中：rolling release 意味着 LLVM 升大版本时偶尔要跟着 reformat / 调整 lint
+> 规则一次（通常一年一两次的事，每次几十分钟工作量）。
 - `fail-fast: false`：一个 job 挂了，不取消其它，方便一次拿到全部失败信息
 - `include`：显式列举 9 组参数（比组合写法 `os: [...] compiler: [...]` 更直观；这个矩阵
   里组合是稀疏的 —— 比如 `clang-cl` 只在 windows-2022 上有意义，所以走 include 不走笛卡尔积）
@@ -261,34 +266,37 @@ env:
 #### Step 3：装编译器
 
 ```yaml
-- name: Install toolchain (Linux container)
+- name: Install toolchain (Arch container)
   if: runner.os == 'Linux'
   run: |
-    apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      g++-15 \
-      clang-20 lld-20 \
-      ninja-build ccache \
-      git curl zip unzip tar pkg-config ca-certificates \
-      python3 python3-pip
+    pacman -Sy --noconfirm --needed \
+      gcc clang lld llvm \
+      cmake ninja make ccache \
+      curl zip unzip tar pkgconf \
+      python python-pip
 ```
-- 在 `ubuntu:25.10` 容器里跑（容器中已经是 root，所以**不需要 sudo**）
-- 一次性把 4 个 Linux job 共用的工具装齐——`g++-15` 给 gcc 系列、`clang-20`/`lld-20`
-  给 clang 系列、`libstdc++-15` 默认随 g++-15 装上（也给 clang job 的 `-stdlib=libstdc++` 用）
-- `git curl zip unzip tar` 是 vcpkg 与 Conan 的运行期依赖（裸 Ubuntu 镜像默认不带）
-- `python3-pip` 留给 Conan job；非 Conan job 多装一点也无害
+- 在 `archlinux:base-devel` 容器里跑（容器已是 root，**不需要 sudo**；`base-devel`
+  group 已含 `gcc` + `make` + 其他 build 工具，但仍显式写出便于阅读）
+- 一次性把 4 个 Linux job 共用的工具装齐——Arch 的 `clang` 包**同时**提供
+  `clang-format` / `clang-tidy` / `clangd`（不像 Ubuntu 拆成 `clang-format-20` 这种
+  -NN 子包），全部走无版本名 → 与 `_clang` preset 里 `CMAKE_C_COMPILER=clang`
+  完全对得上，**不再需要 `update-alternatives`**
+- `curl zip unzip tar pkgconf` 是 vcpkg 与 Conan 的运行期依赖
+- `python python-pip` 留给 Conan job；同时 `python` 也是 lint job `run-clang-tidy`
+  脚本的解释器（缺它会 `env: 'python3': No such file or directory`）
 
 macOS 与 MSYS2 各自有专属安装 step（`brew install ninja` / `msys2/setup-msys2@v2`），
 逻辑相同，按 `runner.os == 'macOS'` / `matrix.uses-msys2` 这种 if 表达式分支。
 
-**为什么 `linux-clang` job 也要装 g++-15？**
+**为什么 `linux-clang` job 也间接需要 gcc / libstdc++？**
 
-Clang 自己**不带 C++ 标准库**，它通过 `-stdlib=libstdc++` 或 `-stdlib=libc++` 选挂哪一份。
-本仓库的 `clang-*` preset 没有显式指定 `-stdlib`，所以 Clang 用系统默认（Ubuntu 上是
-libstdc++）。`ubuntu:25.10` 自带的 libstdc++ 来自 g++-15 包，**它带的 `std::generator` /
-`std::ranges::to` / 第二批 ranges 等 C++23 库特性是 demos 用到的**——所以 clang job
-必须 `apt install g++-15`，不是用来"运行 g++"，而是用来**提供 libstdc++-15 头与库**。
-也可以用 libc++ 替代，但 Ubuntu 25.10 的 libc++ 在 C++23 库覆盖度上比 libstdc++-15 略弱，
+Clang 自己**不带 C++ 标准库**，它通过 `-stdlib=libstdc++` 或 `-stdlib=libc++` 选挂
+哪一份。本仓库的 `clang-*` preset 没有显式指定 `-stdlib`，所以 Clang 用系统默认
+（Linux 上是 libstdc++）。Arch 的 `gcc` 包同时提供 g++ 编译器与匹配版本的
+libstdc++ 头与库（`/usr/include/c++/15/...`），**它带的 `std::generator` /
+`std::ranges::to` / 第二批 ranges 等 C++23 库特性是 demos 用到的**。换言之，clang
+job 必须 `pacman -S gcc`，不是用来"运行 g++"，而是用来**提供匹配版本的 libstdc++ 头与库**。
+也可以用 libc++ 替代，但当前 Arch 的 libc++ 在 C++23 库覆盖度上仍略弱于 libstdc++，
 所以本仓库选 libstdc++ 路线。
 
 #### Step 4：MSVC 环境
@@ -378,22 +386,22 @@ Windows 段同理，只是用 `shell: pwsh` 显式 PowerShell。
 lint:
   name: clang-format + clang-tidy
   runs-on: ubuntu-24.04
-  container: ubuntu:25.10
+  container: archlinux:base-devel
   steps:
     - uses: actions/checkout@v4
-    - name: Install toolchain (clang-20, g++-15, ninja, clang-format-20, clang-tidy-20)
+    - name: Install toolchain (Arch — clang + clang-format + clang-tidy + cmake/ninja)
       run: |
-        apt-get update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-          clang-20 lld-20 g++-15 ninja-build \
-          clang-format-20 clang-tidy-20 \
-          git curl zip unzip tar pkg-config ca-certificates
+        pacman -Sy --noconfirm --needed \
+          clang lld llvm \
+          cmake ninja make \
+          curl zip unzip tar pkgconf \
+          python
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: '5ee5eee0d3e9c6098b24d263e9099edcdcef6631'
     - name: Configure
-      env: { CC: clang-20, CXX: clang++-20, VCPKG_ROOT: ${{ github.workspace }}/vcpkg }
+      env: { CC: clang, CXX: clang++, VCPKG_ROOT: ${{ github.workspace }}/vcpkg }
       run: cmake --preset clang-relwithdebinfo
     - name: clang-format (dry-run)
       run: cmake --build --preset clang-relwithdebinfo --target format-check
@@ -402,12 +410,14 @@ lint:
 ```
 **与 build-test 并行运行**的独立 job，跑两件事：
 
-- **`format-check`**：`clang-format-20 --dry-run --Werror`，检测格式偏差但不改文件。
-  仓库根 `.clang-format` 控制规则。
-- **`tidy-check`**：`clang-tidy-20` 跑全仓 .cpp / .hpp / .h，规则在仓库根 `.clang-tidy`。
+- **`format-check`**：`clang-format --dry-run --Werror`（Arch 上即 LLVM 上游最新版），
+  检测格式偏差但不改文件。仓库根 `.clang-format` 控制规则。
+- **`tidy-check`**：`clang-tidy` 跑全仓 .cpp / .hpp / .h，规则在仓库根 `.clang-tidy`。
   必须先 `configure` 一次让 CMake 写出 `compile_commands.json`，clang-tidy 才知道每个 TU 的 flag。
+- `python` 是 LLVM 包里 `run-clang-tidy` 脚本的解释器（缺它 tidy-check 会
+  `env: 'python3': No such file or directory`）。
 
-> 为什么 lint job 用 `clang-relwithdebinfo` 而不是别的：clang-20 + libstdc++-15
+> 为什么 lint job 用 `clang-relwithdebinfo` 而不是别的：clang + Arch 默认 libstdc++
 > 一起能看到 `<expected>` / `<generator>` / `ranges::to` 等完整的 C++23 stdlib 表面，
 > 模块里的 `try_compile` gate 不会跳过任何 target —— 这就保证 `compile_commands.json`
 > 完整、clang-tidy 的输入集完整。换言之，lint 绿等于每个模块都被 tidy 真正扫过。
@@ -680,7 +690,7 @@ GitHub 会自动展开**最后一个失败的 step**，节省排查时间。
   run: |
     echo "PATH = $PATH"
     cmake --version
-    g++-15 --version
+    g++ --version
     env | sort
 ```
 
@@ -742,7 +752,7 @@ act push
 ```bash
 # 模拟 linux-gcc job 的核心步骤
 export VCPKG_ROOT=/path/to/vcpkg
-export CC=gcc-15 CXX=g++-15
+export CC=gcc CXX=g++
 cmake --preset gcc-relwithdebinfo
 cmake --build --preset gcc-relwithdebinfo --parallel
 ctest --preset gcc-relwithdebinfo
@@ -958,7 +968,7 @@ permissions:
 99% 的原因：
 
 - 你装了某个 vcpkg 全局库 / 系统包，CI 没有
-- 你 CMake/编译器版本和 CI 不一致（Linux jobs 跑在 `ubuntu:25.10` 容器里，apt 默认 g++-15 / clang-20）
+- 你 CMake/编译器版本和 CI 不一致（Linux jobs 跑在 `archlinux:base-devel` 容器里，pacman 滚动 GCC / Clang，本地建议装 LLVM 22+）
 - 路径分隔符问题（`\` vs `/`）
 - 文件名大小写（你 Windows 不区分，Linux 区分）
 - 隐藏的 `.gitignore` 文件没提交，CI 拿不到

--- a/modules/02_lifetime_type_safety/CMakeLists.txt
+++ b/modules/02_lifetime_type_safety/CMakeLists.txt
@@ -1,8 +1,49 @@
 # modules/02_lifetime_type_safety — 生命周期与类型安全 / Lifetime & Type Safety
 #
-# 演示与测试覆盖：对象生命周期、存储期、引用、类型安全、union 的安全使用、
-# placement new。
+# 演示与测试覆盖：
+#   - 生命周期 / 存储期、临时对象延寿、悬空陷阱、placement new、std::launder、
+#     存储复用、std::byte / unsigned char 缓冲区、严格别名（type-punning）。
+#   - 继承扩展：切片问题（slicing）+ clone() 模式、多重继承 + using 声明、
+#     致命菱形 + 虚继承、混入模式（mixin）。
+#   - 类型安全：static_cast / const_cast / reinterpret_cast / std::bit_cast、
+#     dynamic_cast 与 RTTI（typeid / type_index）。
+#   - 类型安全的 union 与 void*：std::variant + std::visit、std::any。
+#
+# 备注：start_lifetime_as / start_lifetime_as_array 是 C++23 的库特性
+# （__cpp_lib_start_lifetime_as ≥ 202207L）。源文件用 feature test 兜底，
+# 缺失时跳过该段代码 —— 不需要 try_compile。
 
-mcpp_add_demo(NAME storage_duration SOURCES demos/storage_duration.cpp)
+include(CheckCXXSourceCompiles)
 
-mcpp_add_test(NAME test_lifetime    SOURCES tests/test_lifetime.cpp)
+# ---- 生命周期 / 存储期相关 demo ----
+mcpp_add_demo(NAME storage_duration    SOURCES demos/storage_duration.cpp)
+mcpp_add_demo(NAME lifetime_extension  SOURCES demos/lifetime_extension.cpp)
+mcpp_add_demo(NAME dangling_pitfalls   SOURCES demos/dangling_pitfalls.cpp)
+mcpp_add_demo(NAME placement_new       SOURCES demos/placement_new.cpp)
+mcpp_add_demo(NAME storage_reuse       SOURCES demos/storage_reuse.cpp)
+mcpp_add_demo(NAME byte_storage        SOURCES demos/byte_storage.cpp)
+
+# ---- 继承扩展相关 demo ----
+mcpp_add_demo(NAME slicing               SOURCES demos/slicing.cpp)
+mcpp_add_demo(NAME multiple_inheritance  SOURCES demos/multiple_inheritance.cpp)
+mcpp_add_demo(NAME virtual_inheritance   SOURCES demos/virtual_inheritance.cpp)
+mcpp_add_demo(NAME mixin_pattern         SOURCES demos/mixin_pattern.cpp)
+
+# ---- 类型安全相关 demo ----
+mcpp_add_demo(NAME casts_overview     SOURCES demos/casts_overview.cpp)
+mcpp_add_demo(NAME dynamic_cast_rtti  SOURCES demos/dynamic_cast_rtti.cpp)
+mcpp_add_demo(NAME variant_visit      SOURCES demos/variant_visit.cpp)
+mcpp_add_demo(NAME any_demo           SOURCES demos/any_demo.cpp)
+
+# ---- 测试 ----
+mcpp_add_test(NAME test_lifetime            SOURCES tests/test_lifetime.cpp)
+mcpp_add_test(NAME test_lifetime_extension  SOURCES tests/test_lifetime_extension.cpp)
+mcpp_add_test(NAME test_placement_new       SOURCES tests/test_placement_new.cpp)
+mcpp_add_test(NAME test_storage_reuse       SOURCES tests/test_storage_reuse.cpp)
+mcpp_add_test(NAME test_aliasing            SOURCES tests/test_aliasing.cpp)
+mcpp_add_test(NAME test_slicing             SOURCES tests/test_slicing.cpp)
+mcpp_add_test(NAME test_inheritance         SOURCES tests/test_inheritance.cpp)
+mcpp_add_test(NAME test_casts               SOURCES tests/test_casts.cpp)
+mcpp_add_test(NAME test_dynamic_cast        SOURCES tests/test_dynamic_cast.cpp)
+mcpp_add_test(NAME test_variant             SOURCES tests/test_variant.cpp)
+mcpp_add_test(NAME test_any                 SOURCES tests/test_any.cpp)

--- a/modules/02_lifetime_type_safety/demos/any_demo.cpp
+++ b/modules/02_lifetime_type_safety/demos/any_demo.cpp
@@ -35,6 +35,9 @@ void print(std::any const& a) {
 
 }  // namespace
 
+// std::cout / std::any_cast 在路径分析下"理论上"可能抛；demo 里我们就是要
+// 演示 bad_any_cast 等异常 —— 让它们离开 main 是预期行为。
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main() {
     std::cout << "[1] 装载 / 取出 / 重置\n";
     {

--- a/modules/02_lifetime_type_safety/demos/any_demo.cpp
+++ b/modules/02_lifetime_type_safety/demos/any_demo.cpp
@@ -1,0 +1,98 @@
+// std::any —— 类型安全的 void*。
+//
+// 关键点：
+//   - std::any 可以装载 *任何* 满足拷贝构造的对象。
+//   - 取出时必须 std::any_cast<T>(a)，且 T 必须与存储类型 *完全相同*（cv 与
+//     引用可加），否则按值版本抛 std::bad_any_cast，按指针版本返回 nullptr。
+//   - std::any 不是 Python 的"动态变量"：它仍是强类型 —— 你必须知道存的是什么。
+//   - SBO（小缓冲区优化）：常见实现把"小、可移动构造 noexcept"的对象放在 any
+//     的栈上字节里，避免堆分配 —— sizeof(std::any) 远比一个指针大。
+
+#include <any>
+#include <iostream>
+#include <map>
+#include <string>
+#include <typeinfo>
+#include <utility>
+
+namespace {
+
+void print(std::any const& a) {
+    if (!a.has_value()) {
+        std::cout << "  <empty>\n";
+        return;
+    }
+    std::cout << "  type = " << a.type().name();
+    if (auto const* pi = std::any_cast<int>(&a); pi != nullptr) {
+        std::cout << "  int=" << *pi;
+    } else if (auto const* pd = std::any_cast<double>(&a); pd != nullptr) {
+        std::cout << "  double=" << *pd;
+    } else if (auto const* ps = std::any_cast<std::string>(&a); ps != nullptr) {
+        std::cout << "  string=\"" << *ps << '"';
+    }
+    std::cout << '\n';
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 装载 / 取出 / 重置\n";
+    {
+        std::any a;
+        print(a);
+
+        a = 42;
+        print(a);
+
+        a = std::string{"hello"};
+        print(a);
+
+        a.reset();
+        std::cout << "  after reset, has_value = " << a.has_value() << '\n';
+    }
+
+    std::cout << "\n[2] any_cast：类型不匹配 -> bad_any_cast\n";
+    {
+        std::any a = 1LL;  // long long
+        try {
+            // 必须 cast 到完全相同的类型
+            std::cout << "  any_cast<int>(long long) = " << std::any_cast<int>(a) << '\n';
+        } catch (std::bad_any_cast const& e) {
+            std::cout << "  caught: " << e.what() << '\n';
+        }
+        // 指针版本：失败返回 nullptr，不抛
+        if (std::any_cast<int>(&a) == nullptr) {
+            std::cout << "  any_cast<int>(&a) == nullptr (与文档一致)\n";
+        }
+        std::cout << "  正确：any_cast<long long>(a) = " << std::any_cast<long long>(a) << '\n';
+    }
+
+    std::cout << "\n[3] in_place_type 构造 + emplace\n";
+    {
+        std::any a{std::in_place_type<std::string>, 5, '*'};  // "*****"
+        std::cout << "  inplace string = " << std::any_cast<std::string>(a) << '\n';
+        a.emplace<std::string>("emplaced");
+        std::cout << "  after emplace  = " << std::any_cast<std::string>(a) << '\n';
+    }
+
+    std::cout << "\n[4] 用作配置项集合（异构 map）\n";
+    {
+        std::map<std::string, std::any> config;
+        config.emplace("port", 8080);
+        config.emplace("hostname", std::string{"localhost"});
+        config.emplace("ratio", 0.75);
+
+        for (auto const& [k, v] : config) {
+            std::cout << "  " << k << " : ";
+            print(v);
+        }
+    }
+
+    std::cout << "\n[5] sizeof(std::any) 反映 SBO 大小\n";
+    {
+        std::cout << "  sizeof(std::any) = " << sizeof(std::any) << '\n';
+        std::cout << "  sizeof(void*)    = " << sizeof(void*) << '\n';
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/byte_storage.cpp
+++ b/modules/02_lifetime_type_safety/demos/byte_storage.cpp
@@ -1,0 +1,92 @@
+// std::byte / unsigned char 缓冲区与 C++23 std::start_lifetime_as(_array)。
+//
+// 关键点：
+//   - std::byte（C++17，<cstddef>）是强类型枚举类，专门表示"一个字节"，比
+//     unsigned char 更不易与算术类型混用。
+//   - 通过 std::byte 或 unsigned char 指针 "看" 任何对象都是合法（严格别名规则
+//     的明确豁免），但反过来不一定。
+//   - C++20 给 std::malloc / std::calloc / 分配器加了 "隐式开始生命周期" 的口子；
+//     但写自己的内存池时，仍可能需要显式调用 C++23 的
+//     std::start_lifetime_as<T>(void*) 或 std::start_lifetime_as_array<T>(void*, n)
+//     才能合法访问。
+//   - 本 demo 在编译期检测 __cpp_lib_start_lifetime_as；不可用则跳过那一段。
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <version>
+
+#if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
+#  include <memory>
+#endif
+
+namespace {
+
+struct Pixel {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+    std::uint8_t a;
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] std::byte 的强类型语义\n";
+    {
+        std::byte b{0x3F};
+        b |= std::byte{0x40};  // 按位运算保持 std::byte 类型
+        std::cout << "  b = 0x" << std::hex << std::to_integer<int>(b) << std::dec << "\n";
+    }
+
+    std::cout << "\n[2] 用 std::byte* 观察任意对象（严格别名豁免）\n";
+    {
+        Pixel const px{.r = 0x12, .g = 0x34, .b = 0x56, .a = 0x78};
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto const* bytes = reinterpret_cast<std::byte const*>(&px);
+        std::cout << "  raw bytes = ";
+        for (std::size_t i = 0; i < sizeof(Pixel); ++i) {
+            std::cout << std::hex << std::to_integer<int>(bytes[i]) << ' ';
+        }
+        std::cout << std::dec << "\n";
+    }
+
+    std::cout << "\n[3] memcpy 在平凡可拷贝类型间做按位等价\n";
+    {
+        Pixel const src{.r = 1, .g = 2, .b = 3, .a = 4};
+        std::uint32_t packed = 0;
+        std::memcpy(&packed, &src, sizeof(packed));
+        Pixel dst{};
+        std::memcpy(&dst, &packed, sizeof(dst));
+        std::cout << "  round-trip dst = (" << +dst.r << "," << +dst.g << "," << +dst.b << ","
+                  << +dst.a << ")\n";
+    }
+
+    std::cout << "\n[4] C++23 std::start_lifetime_as_array （可用时）\n";
+#if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
+    {
+        constexpr std::size_t kCount = 4;
+        auto raw = std::make_unique<std::byte[]>(sizeof(Pixel) * kCount);
+        Pixel const seed[kCount]{
+            {.r = 1, .g = 2, .b = 3, .a = 4},
+            {.r = 5, .g = 6, .b = 7, .a = 8},
+            {.r = 9, .g = 10, .b = 11, .a = 12},
+            {.r = 13, .g = 14, .b = 15, .a = 16},
+        };
+        std::memcpy(raw.get(), seed, sizeof(seed));
+
+        // 直接 reinterpret_cast 后访问是 UB（无 Pixel 对象处于生命周期内）；
+        // start_lifetime_as_array 让 kCount 个 Pixel 隐式开始生命周期。
+        Pixel* arr = std::start_lifetime_as_array<Pixel>(raw.get(), kCount);
+        for (std::size_t i = 0; i < kCount; ++i) {
+            std::cout << "  arr[" << i << "] = (" << +arr[i].r << "," << +arr[i].g << ","
+                      << +arr[i].b << "," << +arr[i].a << ")\n";
+        }
+    }
+#else
+    std::cout << "  当前 stdlib 未实现 std::start_lifetime_as —— 跳过\n";
+#endif
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/byte_storage.cpp
+++ b/modules/02_lifetime_type_safety/demos/byte_storage.cpp
@@ -18,7 +18,7 @@
 #include <version>
 
 #if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
-#  include <memory>
+#include <memory>
 #endif
 
 namespace {

--- a/modules/02_lifetime_type_safety/demos/casts_overview.cpp
+++ b/modules/02_lifetime_type_safety/demos/casts_overview.cpp
@@ -47,7 +47,7 @@ int main() {
         // 枚举类与底层整数互转
         Color c = Color::Green;
         auto raw = static_cast<std::uint8_t>(c);
-        Color back = static_cast<Color>(raw);
+        auto back = static_cast<Color>(raw);
         std::cout << "  Color(2) <-> raw=" << +raw << " back=" << static_cast<int>(back) << '\n';
 
         // 用单参构造函数构造新对象
@@ -58,7 +58,7 @@ int main() {
         Derived d;
         Base* up = static_cast<Base*>(&d);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-        Derived* down = static_cast<Derived*>(up);  // 已知底层就是 Derived，所以安全
+        auto* down = static_cast<Derived*>(up);  // 已知底层就是 Derived，所以安全
         std::cout << "  up->b=" << up->b << "  down->d=" << down->d << '\n';
     }
 
@@ -88,7 +88,7 @@ int main() {
         std::cout << "  &x as uintptr_t = 0x" << std::hex << p << std::dec << '\n';
         // 转回去得到原指针 —— 与 reinterpret_cast<unsigned int*>(p) 等价
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
-        unsigned int* q = reinterpret_cast<unsigned int*>(p);
+        auto* q = reinterpret_cast<unsigned int*>(p);
         std::cout << "  *q = 0x" << std::hex << *q << std::dec << '\n';
     }
 

--- a/modules/02_lifetime_type_safety/demos/casts_overview.cpp
+++ b/modules/02_lifetime_type_safety/demos/casts_overview.cpp
@@ -48,8 +48,7 @@ int main() {
         Color c = Color::Green;
         auto raw = static_cast<std::uint8_t>(c);
         Color back = static_cast<Color>(raw);
-        std::cout << "  Color(2) <-> raw=" << +raw << " back="
-                  << static_cast<int>(back) << '\n';
+        std::cout << "  Color(2) <-> raw=" << +raw << " back=" << static_cast<int>(back) << '\n';
 
         // 用单参构造函数构造新对象
         auto counted = static_cast<Counted>(42);

--- a/modules/02_lifetime_type_safety/demos/casts_overview.cpp
+++ b/modules/02_lifetime_type_safety/demos/casts_overview.cpp
@@ -1,0 +1,111 @@
+// 四种 C++ 命名转换 + C 风格转换的对照。
+//
+// 关键点：
+//   - static_cast：编译期"显式但合理"的转换 —— 数值缩窄、枚举互转、上下转、
+//     void* 与具体指针互转、构造新对象、转 void 丢值等等。
+//   - dynamic_cast：仅用于多态类型的安全继承转换；失败则指针返回 nullptr，
+//     引用抛 std::bad_cast。详见 dynamic_cast_rtti.cpp。
+//   - const_cast：去掉 / 加上 const / volatile —— 不会改变对象本身，只是改变
+//     指针 / 引用的访问权。对原本不可写的对象写入是 UB。
+//   - reinterpret_cast：低层位级转换；几乎只在指针互转 / 指针 ↔ 整数时使用。
+//     真正的"按位重读"应该用 std::bit_cast 或 std::memcpy。
+//   - C 风格 (T)x：以上几种依次尝试，并能忽略访问控制 —— 失去了显式提示的
+//     好处，建议永远不用。
+
+#include <bit>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+namespace {
+
+enum class Color : std::uint8_t { Red = 1, Green = 2, Blue = 3 };
+
+struct Counted {
+    int value;
+    explicit Counted(int v) : value(v) {}  // 单参构造可被 static_cast<Counted>(int) 选中
+};
+
+struct Base {
+    int b{1};
+    virtual ~Base() = default;
+};
+struct Derived : Base {
+    int d{2};
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] static_cast：数值 / 枚举 / 构造对象 / 上下转\n";
+    {
+        // 数值缩窄（显式表达"我知道在缩窄"）
+        double dpi = 3.14;
+        int truncated = static_cast<int>(dpi);
+        std::cout << "  double->int trunc = " << truncated << '\n';
+
+        // 枚举类与底层整数互转
+        Color c = Color::Green;
+        auto raw = static_cast<std::uint8_t>(c);
+        Color back = static_cast<Color>(raw);
+        std::cout << "  Color(2) <-> raw=" << +raw << " back="
+                  << static_cast<int>(back) << '\n';
+
+        // 用单参构造函数构造新对象
+        auto counted = static_cast<Counted>(42);
+        std::cout << "  Counted{42}.value = " << counted.value << '\n';
+
+        // 多态指针上转 / 下转
+        Derived d;
+        Base* up = static_cast<Base*>(&d);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        Derived* down = static_cast<Derived*>(up);  // 已知底层就是 Derived，所以安全
+        std::cout << "  up->b=" << up->b << "  down->d=" << down->d << '\n';
+    }
+
+    std::cout << "\n[2] const_cast：去掉 const 进入非 const 接口（必须保证原对象可写）\n";
+    {
+        std::string s{"hello"};
+        // 第三方 API 设计失误：参数应当是 string& 但写成了 string const& —— 我们手上
+        // 的 s 实际上可写，所以 const_cast 安全。
+        auto fix_in_place = [](std::string const& cs) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+            auto& mut = const_cast<std::string&>(cs);
+            mut[0] = 'H';
+        };
+        fix_in_place(s);
+        std::cout << "  after const_cast write: " << s << '\n';
+
+        // 反例（不写代码，仅文字说明）：对真正只读对象用 const_cast 写入是 UB。
+        //   const int kImmortal = 1;
+        //   const_cast<int&>(kImmortal) = 2;   // UB
+    }
+
+    std::cout << "\n[3] reinterpret_cast：指针 ↔ 整数 / 不同对象指针互转（受严格别名约束）\n";
+    {
+        unsigned int x = 0xDEADBEEF;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto p = reinterpret_cast<std::uintptr_t>(&x);
+        std::cout << "  &x as uintptr_t = 0x" << std::hex << p << std::dec << '\n';
+        // 转回去得到原指针 —— 与 reinterpret_cast<unsigned int*>(p) 等价
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+        unsigned int* q = reinterpret_cast<unsigned int*>(p);
+        std::cout << "  *q = 0x" << std::hex << *q << std::dec << '\n';
+    }
+
+    std::cout << "\n[4] 想按位重读应该用 std::bit_cast，而非 reinterpret_cast\n";
+    {
+        float f = 1.0F;
+        auto bits = std::bit_cast<std::uint32_t>(f);  // 1065353216 = 0x3F800000
+        std::cout << "  bit_cast<uint32_t>(1.0f) = 0x" << std::hex << bits << std::dec << '\n';
+    }
+
+    std::cout << "\n[5] static_cast<void>(expr) —— 显式丢弃返回值 / 抑制 unused 警告\n";
+    {
+        int unused = 42;
+        static_cast<void>(unused);  // 与 (void)unused; 等价
+        std::cout << "  ok\n";
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/dangling_pitfalls.cpp
+++ b/modules/02_lifetime_type_safety/demos/dangling_pitfalls.cpp
@@ -1,0 +1,124 @@
+// 各种悬空 / 越生命周期使用的反例与正确做法。
+//
+// 覆盖文档中点到的几类陷阱：
+//   - 返回指向局部变量的引用 / 指针。
+//   - lambda 引用捕获，但 lambda 寿命比所引用对象长（被赋给 std::function）。
+//   - 类成员函数中的 lambda 通过 this 捕获成员，对象销毁后 this 悬空。
+//   - 返回 view（如 v | reverse）但底层容器已析构。
+//
+// "真的运行 UB" 的代码路径只有定义 MCPP_DEMONSTRATE_UB 时才编译；默认禁用，
+// 这样 CI 的 -Werror / clang-tidy 不会被触发。
+
+#include <functional>
+#include <iostream>
+#include <ranges>
+#include <vector>
+
+namespace {
+
+#if defined(MCPP_DEMONSTRATE_UB)
+// 反例 1：返回局部对象的引用
+[[nodiscard]] int const& localRef() {
+    int local = 42;
+    return local;
+}
+#endif
+
+[[nodiscard]] int localValue() {
+    int local = 42;
+    return local;
+}
+
+#if defined(MCPP_DEMONSTRATE_UB)
+// 反例 2：把"引用捕获的 lambda"赋给比捕获对象活得更久的 std::function
+[[nodiscard]] std::function<int()> makeDanglingCounter() {
+    int counter = 100;
+    return [&counter] { return counter; };
+}
+#endif
+
+[[nodiscard]] std::function<int()> makeSafeCounter() {
+    int counter = 100;
+    return [counter] { return counter; };
+}
+
+// 反例 3：成员函数里的 [&] / [=] 不会真的拷贝成员 —— 它们都通过 this 访问
+struct Widget {
+    int value{7};
+
+    [[nodiscard]] std::function<int()> badLambda() {
+        // 捕获 this：调用方拿到的 lambda 在 *this 销毁后失效。
+        return [this] { return value; };
+    }
+
+    [[nodiscard]] std::function<int()> safeLambdaCopyThis() const {
+        return [*this] { return value; };  // 拷贝 *this
+    }
+
+    [[nodiscard]] std::function<int()> safeLambdaCopyValue() const {
+        int v = value;
+        return [v] { return v; };
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 返回局部值 vs 局部引用\n";
+    std::cout << "  localValue() = " << localValue() << "\n";
+#if defined(MCPP_DEMONSTRATE_UB)
+    std::cout << "  localRef()   = " << localRef() << "  (UB!)\n";
+#else
+    std::cout << "  localRef()   = <skipped: see source comments>\n";
+#endif
+
+    std::cout << "\n[2] 引用捕获 lambda 越界使用\n";
+    {
+#if defined(MCPP_DEMONSTRATE_UB)
+        auto dangling = makeDanglingCounter();
+        std::cout << "  dangling() = " << dangling() << "  (读已死栈帧)\n";
+#else
+        std::cout << "  dangling() = <skipped: would read dead stack frame>\n";
+#endif
+
+        auto safe = makeSafeCounter();
+        std::cout << "  safe()     = " << safe() << "\n";
+    }
+
+    std::cout << "\n[3] 类成员里 lambda 的捕获\n";
+    {
+        std::function<int()> f1;
+        std::function<int()> f2;
+        std::function<int()> f3;
+        {
+            Widget w{};
+            f1 = w.badLambda();
+            f2 = w.safeLambdaCopyThis();
+            f3 = w.safeLambdaCopyValue();
+        }
+        // 离开块后 w 已死。f1 调用是 UB；f2/f3 仍然安全。
+#if defined(MCPP_DEMONSTRATE_UB)
+        std::cout << "  f1() = " << f1() << "  (UB!)\n";
+#else
+        std::cout << "  f1() = <skipped: w is dead>\n";
+        (void)f1;
+#endif
+        std::cout << "  f2() = " << f2() << "\n";
+        std::cout << "  f3() = " << f3() << "\n";
+    }
+
+    std::cout << "\n[4] view（ranges）必须比底层容器活得短\n";
+    {
+        std::vector<int> v{1, 2, 3, 4, 5};
+        auto rv = v | std::views::reverse;
+        std::cout << "  reversed: ";
+        for (int x : rv) {
+            std::cout << x << ' ';
+        }
+        std::cout << "\n";
+        // 反例（仅文字说明）：从函数返回左值容器之上的 view 会悬空 —— 容器
+        // 已析构，view 内部的 ref_view 指向死内存。
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/dangling_pitfalls.cpp
+++ b/modules/02_lifetime_type_safety/demos/dangling_pitfalls.cpp
@@ -16,7 +16,7 @@
 
 namespace {
 
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
 // 反例 1：返回局部对象的引用
 [[nodiscard]] int const& localRef() {
     int local = 42;
@@ -29,7 +29,7 @@ namespace {
     return local;
 }
 
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
 // 反例 2：把"引用捕获的 lambda"赋给比捕获对象活得更久的 std::function
 [[nodiscard]] std::function<int()> makeDanglingCounter() {
     int counter = 100;
@@ -66,7 +66,7 @@ struct Widget {
 int main() {
     std::cout << "[1] 返回局部值 vs 局部引用\n";
     std::cout << "  localValue() = " << localValue() << "\n";
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
     std::cout << "  localRef()   = " << localRef() << "  (UB!)\n";
 #else
     std::cout << "  localRef()   = <skipped: see source comments>\n";
@@ -74,7 +74,7 @@ int main() {
 
     std::cout << "\n[2] 引用捕获 lambda 越界使用\n";
     {
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
         auto dangling = makeDanglingCounter();
         std::cout << "  dangling() = " << dangling() << "  (读已死栈帧)\n";
 #else
@@ -97,7 +97,7 @@ int main() {
             f3 = w.safeLambdaCopyValue();
         }
         // 离开块后 w 已死。f1 调用是 UB；f2/f3 仍然安全。
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
         std::cout << "  f1() = " << f1() << "  (UB!)\n";
 #else
         std::cout << "  f1() = <skipped: w is dead>\n";

--- a/modules/02_lifetime_type_safety/demos/dynamic_cast_rtti.cpp
+++ b/modules/02_lifetime_type_safety/demos/dynamic_cast_rtti.cpp
@@ -1,0 +1,123 @@
+// dynamic_cast 与 RTTI（typeid / type_index）。
+//
+// 关键点：
+//   - dynamic_cast 仅对多态类型生效 —— 至少有一个虚函数（通常是虚析构）。
+//   - dynamic_cast<T*>(p)：失败返回 nullptr；dynamic_cast<T&>(r)：失败抛 bad_cast。
+//   - 可做下转 / 同层多重继承的"侧向转换"（sidecast）；普通 static_cast 无法在
+//     无直接继承关系的兄弟之间转换。
+//   - dynamic_cast<void*>(p) 给你"指向最派生对象起点"的指针 —— 极少用，但是少数
+//     还能在 base* 上拿到完整对象首地址的方式。
+//   - typeid(expr) -> std::type_info；用 std::type_index 包装可放进关联容器。
+//   - RTTI 在性能敏感路径上慢很多；多数场景应该靠 virtual 派发或 std::variant
+//     代替；这里只展示 API。
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+
+namespace {
+
+struct Animal {
+    virtual ~Animal() = default;
+    [[nodiscard]] virtual std::string sound() const = 0;
+};
+
+struct Cat : Animal {
+    [[nodiscard]] std::string sound() const override {
+        return "meow";
+    }
+};
+
+struct Dog : Animal {
+    [[nodiscard]] std::string sound() const override {
+        return "woof";
+    }
+    [[nodiscard]] virtual std::string fetch() const {
+        return "fetch!";
+    }
+};
+
+// 演示侧向转换：菱形里的两条腿
+struct Swims {
+    virtual ~Swims() = default;
+    [[nodiscard]] virtual std::string swim() const = 0;
+};
+struct Walks {
+    virtual ~Walks() = default;
+    [[nodiscard]] virtual std::string walk() const = 0;
+};
+struct Frog : Swims, Walks {
+    [[nodiscard]] std::string swim() const override {
+        return "frog-swim";
+    }
+    [[nodiscard]] std::string walk() const override {
+        return "frog-walk";
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 指针下转：成功返回派生指针，失败返回 nullptr\n";
+    {
+        std::unique_ptr<Animal> a = std::make_unique<Dog>();
+        if (auto* d = dynamic_cast<Dog*>(a.get()); d != nullptr) {
+            std::cout << "  Dog* 拿到了：" << d->sound() << " / " << d->fetch() << '\n';
+        }
+        if (dynamic_cast<Cat*>(a.get()) == nullptr) {
+            std::cout << "  Cat* 失败，返回 nullptr（底层不是 Cat）\n";
+        }
+    }
+
+    std::cout << "\n[2] 引用下转：失败抛 std::bad_cast\n";
+    {
+        Cat c;
+        Animal& a = c;
+        try {
+            auto& d = dynamic_cast<Dog&>(a);  // 必败
+            (void)d;
+        } catch (std::bad_cast const& e) {
+            std::cout << "  caught bad_cast: " << e.what() << '\n';
+        }
+    }
+
+    std::cout << "\n[3] 侧向转换（sidecast）：从 Swims 到 Walks（两边都不直接继承）\n";
+    {
+        Frog f;
+        Swims& s = f;
+        // static_cast<Walks&>(s) —— 编译错，不是直接继承关系
+        auto& w = dynamic_cast<Walks&>(s);
+        std::cout << "  via Swims&  -> walk(): " << w.walk() << '\n';
+    }
+
+    std::cout << "\n[4] dynamic_cast<void*>：取最派生对象起点\n";
+    {
+        Frog f;
+        Swims& s = f;
+        Walks& w = f;
+        // 注意：&s 与 &w 通常 *不* 等于 &f；dynamic_cast<void*> 才是
+        void const* most_derived_via_s = dynamic_cast<void const*>(&s);
+        void const* most_derived_via_w = dynamic_cast<void const*>(&w);
+        std::cout << "  same most-derived: "
+                  << (most_derived_via_s == most_derived_via_w ? "yes" : "no") << '\n';
+    }
+
+    std::cout << "\n[5] typeid + type_index：把类型当 map key\n";
+    {
+        std::map<std::type_index, std::string> labels;
+        Cat c;
+        Dog d;
+        labels.emplace(typeid(c), "Cat instance");
+        labels.emplace(typeid(d), "Dog instance");
+        labels.emplace(typeid(int), "int");
+
+        for (auto const& [k, v] : labels) {
+            std::cout << "  " << k.name() << " => " << v << '\n';
+        }
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/lifetime_extension.cpp
+++ b/modules/02_lifetime_type_safety/demos/lifetime_extension.cpp
@@ -1,0 +1,108 @@
+// 临时对象的生命周期延长（lifetime extension）。
+//
+// 核心规则：
+//   - 临时对象只活到产生它那条 *完整表达式* 结束（即下一个 `;`）。
+//   - 但 const T& 与 T&& 这类 *直接* 绑定到纯右值的引用可以把临时对象的寿命
+//     延长到该引用的作用域结束 —— 这是少数能"延寿"的情形之一。
+//   - 注意：只有 *直接* 绑定才有效。从函数返回引用、把引用塞进结构体、再
+//     从中拿出来都会破坏延寿条件 —— 这是返回 string_view / 临时引用的经典坑。
+//   - C++23 起，range-based for 的初始化器中产生的 *所有* 临时对象寿命也会
+//     延长到 for 循环结束（修复了"for(auto& x : f().items()) 悬空"的老坑）。
+//
+// 本 demo 通过带计数的 Probe 显式打印构造/析构时刻，让"延寿/不延寿"一目了然。
+// 反例（返回局部引用 / 通过函数包装绑定的引用）默认不编译；定义
+// MCPP_DEMONSTRATE_UB 才会启用，便于学习者主动观察 UB。
+
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace {
+
+struct Probe {
+    std::string name;
+    static int alive;
+
+    explicit Probe(std::string n) : name(std::move(n)) {
+        ++alive;
+        std::cout << "  + ctor  " << name << "  (alive=" << alive << ")\n";
+    }
+    Probe(Probe const& o) : name(o.name + "/copy") {
+        ++alive;
+        std::cout << "  + copy  " << name << "  (alive=" << alive << ")\n";
+    }
+    Probe(Probe&&) = delete;
+    Probe& operator=(Probe const&) = delete;
+    Probe& operator=(Probe&&) = delete;
+    ~Probe() {
+        --alive;
+        std::cout << "  - dtor  " << name << "  (alive=" << alive << ")\n";
+    }
+};
+
+int Probe::alive = 0;
+
+[[nodiscard]] Probe makeProbe(std::string n) {
+    return Probe{std::move(n)};
+}
+
+#if defined(MCPP_DEMONSTRATE_UB)
+// 反例（默认禁用）：返回的"引用"指向 return 行结束就死亡的临时。
+[[nodiscard]] Probe const& dangerousRef() {
+    return Probe{"inside_func"};
+}
+#endif
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 临时对象只活到 ; ——\n";
+    {
+        std::cout << "  before-stmt\n";
+        std::string s = makeProbe("temp1").name;  // 拷贝出 string 后立刻销毁临时
+        std::cout << "  after-stmt: s=" << s << "\n";
+    }
+
+    std::cout << "\n[2] const& 直接绑定纯右值 —— 寿命延长到引用作用域\n";
+    {
+        Probe const& ref = makeProbe("temp2");  // 临时寿命延长到块末尾
+        std::cout << "  middle: alive=" << Probe::alive << " name=" << ref.name << "\n";
+    }
+    std::cout << "  alive after block = " << Probe::alive << "\n";
+
+    std::cout << "\n[3] 右值引用同样可以延寿\n";
+    {
+        Probe&& rref = makeProbe("temp3");
+        std::cout << "  middle: name=" << rref.name << "\n";
+    }
+
+    std::cout << "\n[4] 反例：返回值经过函数 / 成员就丢失延寿\n";
+#if defined(MCPP_DEMONSTRATE_UB)
+    {
+        Probe const& bad = dangerousRef();
+        std::cout << "  alive after returning dangling ref = " << Probe::alive
+                  << " (临时早已析构)\n";
+        (void)bad;
+    }
+#else
+    std::cout << "  <编译时定义 MCPP_DEMONSTRATE_UB 才会真的执行>\n";
+#endif
+
+    std::cout << "\n[5] C++23 起 range-based for 的初始化器内所有临时都延寿\n";
+    {
+        struct Bag {
+            int data[3]{1, 2, 3};
+            int* begin() {
+                return data;
+            }
+            int* end() {
+                return data + 3;
+            }
+        };
+        for (int x : Bag{}) {
+            std::cout << "  for x=" << x << "\n";
+        }
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/lifetime_extension.cpp
+++ b/modules/02_lifetime_type_safety/demos/lifetime_extension.cpp
@@ -46,7 +46,7 @@ int Probe::alive = 0;
     return Probe{std::move(n)};
 }
 
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
 // 反例（默认禁用）：返回的"引用"指向 return 行结束就死亡的临时。
 [[nodiscard]] Probe const& dangerousRef() {
     return Probe{"inside_func"};
@@ -77,7 +77,7 @@ int main() {
     }
 
     std::cout << "\n[4] 反例：返回值经过函数 / 成员就丢失延寿\n";
-#if defined(MCPP_DEMONSTRATE_UB)
+#ifdef MCPP_DEMONSTRATE_UB
     {
         Probe const& bad = dangerousRef();
         std::cout << "  alive after returning dangling ref = " << Probe::alive

--- a/modules/02_lifetime_type_safety/demos/mixin_pattern.cpp
+++ b/modules/02_lifetime_type_safety/demos/mixin_pattern.cpp
@@ -1,0 +1,117 @@
+// 混入模式（mixin pattern）—— 多重继承的"安全"用法。
+//
+// 关键点：
+//   - 把每种"能力"做成只含纯虚函数 / 没有数据成员的抽象基类（接口），
+//     派生类按需多重继承组合 —— 等价于 Java/C# 的 interface。
+//   - 因为接口没有数据成员，菱形继承不会重复存数据；vptr 开销也是有限的。
+//   - 这种风格让 "战争模拟里的可攻击 / 可防御 / 可移动单位" 这类场景能用
+//     dynamic_cast 或 std::visit 在运行时按能力分派。
+
+#include <array>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+// 三个能力接口：纯接口（无数据成员，只有 = 0 的虚函数）
+struct Attacker {
+    virtual ~Attacker() = default;
+    [[nodiscard]] virtual int attackPower() const = 0;
+};
+
+struct Defender {
+    virtual ~Defender() = default;
+    [[nodiscard]] virtual int defense() const = 0;
+};
+
+struct Movable {
+    virtual ~Movable() = default;
+    [[nodiscard]] virtual int speed() const = 0;
+};
+
+// Unit：所有单位的公共部分（命名 + 多态析构）
+struct Unit {
+    std::string name;
+    explicit Unit(std::string n) : name(std::move(n)) {}
+    virtual ~Unit() = default;
+};
+
+// Soldier：可攻击 + 可防御 + 可移动
+struct Soldier : Unit, Attacker, Defender, Movable {
+    using Unit::Unit;
+    [[nodiscard]] int attackPower() const override {
+        return 30;
+    }
+    [[nodiscard]] int defense() const override {
+        return 20;
+    }
+    [[nodiscard]] int speed() const override {
+        return 5;
+    }
+};
+
+// Tower：可攻击 + 可防御，但 *不可* 移动
+struct Tower : Unit, Attacker, Defender {
+    using Unit::Unit;
+    [[nodiscard]] int attackPower() const override {
+        return 80;
+    }
+    [[nodiscard]] int defense() const override {
+        return 100;
+    }
+};
+
+// Worker：只可移动（侦察兵）
+struct Worker : Unit, Movable {
+    using Unit::Unit;
+    [[nodiscard]] int speed() const override {
+        return 8;
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 用 dynamic_cast 在 Unit* 上按能力分派\n";
+    {
+        std::vector<std::unique_ptr<Unit>> army;
+        army.push_back(std::make_unique<Soldier>("S1"));
+        army.push_back(std::make_unique<Tower>("T1"));
+        army.push_back(std::make_unique<Worker>("W1"));
+
+        for (auto const& u : army) {
+            std::cout << "  " << u->name << ": ";
+            if (auto const* a = dynamic_cast<Attacker const*>(u.get()); a != nullptr) {
+                std::cout << "attack=" << a->attackPower() << ' ';
+            }
+            if (auto const* d = dynamic_cast<Defender const*>(u.get()); d != nullptr) {
+                std::cout << "defense=" << d->defense() << ' ';
+            }
+            if (auto const* m = dynamic_cast<Movable const*>(u.get()); m != nullptr) {
+                std::cout << "speed=" << m->speed() << ' ';
+            }
+            std::cout << '\n';
+        }
+    }
+
+    std::cout << "\n[2] 接口集合的总伤害（只挑可攻击者）\n";
+    {
+        std::array<std::unique_ptr<Unit>, 3> party{
+            std::make_unique<Soldier>("S2"),
+            std::make_unique<Tower>("T2"),
+            std::make_unique<Worker>("W2"),
+        };
+        int total = 0;
+        for (auto const& u : party) {
+            if (auto const* a = dynamic_cast<Attacker const*>(u.get()); a != nullptr) {
+                total += a->attackPower();
+            }
+        }
+        std::cout << "  total attack power = " << total << '\n';
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
@@ -1,0 +1,98 @@
+// 多重继承基础 + 同名成员消歧 + using 声明。
+//
+// 关键点：
+//   - 一个类可以有多个直接基类；每多一个 *多态* 基类，就多一个 vptr。
+//   - 不同基类有同名成员时，派生类访问需要 Base::method 显式消歧，否则编译报错。
+//   - using Base::method 把基类成员引入派生类作用域，重新打开访问 / 暴露重载。
+//   - 构造函数继承（using Base::Base）允许派生类直接复用父类构造函数 —— 但
+//     编译器自动生成的特殊成员（如默认构造）不会被继承。
+
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace {
+
+struct Swimmer {
+    int swim_speed = 50;
+    void move() const {
+        std::cout << "  Swimmer::move() —— 游泳，速度=" << swim_speed << "\n";
+    }
+    void stamina() const {
+        std::cout << "  Swimmer::stamina = " << swim_speed << "\n";
+    }
+};
+
+struct Runner {
+    int run_speed = 80;
+    void move() const {
+        std::cout << "  Runner::move() —— 奔跑，速度=" << run_speed << "\n";
+    }
+    void stamina() const {
+        std::cout << "  Runner::stamina = " << run_speed << "\n";
+    }
+};
+
+// 多重继承：派生类同时是 Swimmer 与 Runner
+struct Triathlete : Swimmer, Runner {
+    // 解决同名成员二义性：用 using 显式选择 / 暴露 / 重命名
+    using Runner::move;       // move() 沿用 Runner 版本
+    using Swimmer::stamina;   // stamina() 沿用 Swimmer 版本
+};
+
+// 构造函数继承：BaseHolder 把 std::string 的构造交给基类
+struct StringHolder {
+    std::string value;
+    explicit StringHolder(std::string v) : value(std::move(v)) {}
+    explicit StringHolder(int n) : value(n, 'x') {}  // n 个 'x'
+    void show() const {
+        std::cout << "  value=" << value << "\n";
+    }
+};
+
+struct LoggingHolder : StringHolder {
+    using StringHolder::StringHolder;  // 继承所有 StringHolder 构造函数
+    void show() const {
+        std::cout << "[log] ";
+        StringHolder::show();
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 同名成员的二义性 —— 用 using 解决\n";
+    {
+        Triathlete t;
+        t.move();     // 因为 using Runner::move; -> Runner 版本
+        t.stamina();  // 因为 using Swimmer::stamina; -> Swimmer 版本
+
+        // 没有 using 也可显式 t.Swimmer::move();
+        t.Swimmer::move();
+        t.Runner::stamina();
+    }
+
+    std::cout << "\n[2] 构造函数继承：派生类自动暴露父类的所有构造\n";
+    {
+        LoggingHolder a{"abc"};   // 用 std::string 构造
+        LoggingHolder b{3};       // 用 int 构造（n 个 'x'）
+        a.show();
+        b.show();
+    }
+
+    std::cout << "\n[3] 多重继承下的对象大小（每个多态基类各占一个 vptr）\n";
+    {
+        struct A {
+            virtual ~A() = default;
+        };
+        struct B {
+            virtual ~B() = default;
+        };
+        struct C : A, B {};
+        std::cout << "  sizeof(A) = " << sizeof(A) << '\n';
+        std::cout << "  sizeof(B) = " << sizeof(B) << '\n';
+        std::cout << "  sizeof(C) = " << sizeof(C) << "  (>= 2 * sizeof(void*))\n";
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
@@ -53,6 +53,10 @@ struct StringHolder {
 
 struct LoggingHolder : StringHolder {
     using StringHolder::StringHolder;  // 继承所有 StringHolder 构造函数
+
+    // 故意演示"派生类同名非虚函数隐藏基类版本"这一坑 —— 这就是 demo 要传达
+    // 的教学点；clang-tidy 21+ 把它列为新警告，但这里的"隐藏"是有意为之。
+    // NOLINTNEXTLINE(bugprone-derived-method-shadowing-base-method)
     void show() const {
         std::cout << "[log] ";
         StringHolder::show();

--- a/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
@@ -36,8 +36,8 @@ struct Runner {
 // 多重继承：派生类同时是 Swimmer 与 Runner
 struct Triathlete : Swimmer, Runner {
     // 解决同名成员二义性：用 using 显式选择 / 暴露 / 重命名
-    using Runner::move;       // move() 沿用 Runner 版本
-    using Swimmer::stamina;   // stamina() 沿用 Swimmer 版本
+    using Runner::move;      // move() 沿用 Runner 版本
+    using Swimmer::stamina;  // stamina() 沿用 Swimmer 版本
 };
 
 // 构造函数继承：BaseHolder 把 std::string 的构造交给基类
@@ -74,8 +74,8 @@ int main() {
 
     std::cout << "\n[2] 构造函数继承：派生类自动暴露父类的所有构造\n";
     {
-        LoggingHolder a{"abc"};   // 用 std::string 构造
-        LoggingHolder b{3};       // 用 int 构造（n 个 'x'）
+        LoggingHolder a{"abc"};  // 用 std::string 构造
+        LoggingHolder b{3};      // 用 int 构造（n 个 'x'）
         a.show();
         b.show();
     }

--- a/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/demos/multiple_inheritance.cpp
@@ -7,6 +7,7 @@
 //   - 构造函数继承（using Base::Base）允许派生类直接复用父类构造函数 —— 但
 //     编译器自动生成的特殊成员（如默认构造）不会被继承。
 
+#include <cstddef>
 #include <iostream>
 #include <string>
 #include <utility>
@@ -44,7 +45,7 @@ struct Triathlete : Swimmer, Runner {
 struct StringHolder {
     std::string value;
     explicit StringHolder(std::string v) : value(std::move(v)) {}
-    explicit StringHolder(int n) : value(n, 'x') {}  // n 个 'x'
+    explicit StringHolder(int n) : value(static_cast<std::size_t>(n), 'x') {}  // n 个 'x'
     void show() const {
         std::cout << "  value=" << value << "\n";
     }

--- a/modules/02_lifetime_type_safety/demos/placement_new.cpp
+++ b/modules/02_lifetime_type_safety/demos/placement_new.cpp
@@ -1,0 +1,127 @@
+// placement new 与 std::launder。
+//
+// 关键点：
+//   - placement new 不分配内存，只在指定地址 "构造对象"；析构必须手工调用。
+//   - 缓冲区必须满足类型对齐 —— 用 alignas(T) 或 std::aligned_storage_for_t。
+//   - 在已构造对象的存储上再 placement new 一个 *相同类型* 的新对象后，原指针
+//     在简单情形下仍可用（pointer-interconvertible），但若新旧对象类型不同，
+//     或外层类型含有 const / 引用成员，必须用 std::launder 才能合法访问。
+//   - placement new 后必须显式 obj.~T()，否则会泄露资源（如 std::string 的堆缓冲）。
+
+#include <cstddef>
+#include <iostream>
+#include <new>
+#include <string>
+#include <utility>
+
+namespace {
+
+struct Greeter {
+    std::string greeting;
+
+    explicit Greeter(std::string s) : greeting(std::move(s)) {
+        std::cout << "  Greeter::ctor  '" << greeting << "'\n";
+    }
+    ~Greeter() {
+        std::cout << "  Greeter::dtor  '" << greeting << "'\n";
+    }
+    Greeter(Greeter const&) = delete;
+    Greeter(Greeter&&) = delete;
+    Greeter& operator=(Greeter const&) = delete;
+    Greeter& operator=(Greeter&&) = delete;
+};
+
+// 含 const 成员的类型：替换存储后必须用 std::launder 才能读。
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+struct WithConst {
+    int const id;
+    int value;
+};
+
+// 一个固定容量的小池子；放在命名空间作用域，方便模板成员函数。
+struct Pool {
+    static constexpr std::size_t kSlots = 2;
+    alignas(Greeter) std::byte storage[sizeof(Greeter) * kSlots]{};
+    bool occupied[kSlots]{false, false};
+
+    template <class... Args>
+    Greeter* construct(std::size_t slot, Args&&... args) {
+        auto* mem = storage + (sizeof(Greeter) * slot);
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* p = ::new (mem) Greeter{std::forward<Args>(args)...};
+        occupied[slot] = true;
+        return p;
+    }
+
+    void destroy(std::size_t slot) {
+        if (!occupied[slot]) {
+            return;
+        }
+        auto* mem = storage + (sizeof(Greeter) * slot);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-owning-memory)
+        std::launder(reinterpret_cast<Greeter*>(mem))->~Greeter();
+        occupied[slot] = false;
+    }
+
+    Pool() = default;
+    Pool(Pool const&) = delete;
+    Pool(Pool&&) = delete;
+    Pool& operator=(Pool const&) = delete;
+    Pool& operator=(Pool&&) = delete;
+    ~Pool() {
+        destroy(0);
+        destroy(1);
+    }
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 在栈上的对齐缓冲区构造 / 析构\n";
+    {
+        alignas(Greeter) std::byte buf[sizeof(Greeter)];
+        Greeter* p = ::new (buf) Greeter{"hello"};  // NOLINT(cppcoreguidelines-owning-memory)
+        std::cout << "  via p: " << p->greeting << "\n";
+        p->~Greeter();
+    }
+
+    std::cout << "\n[2] 同一缓冲上构造、析构、再构造（同类型，无 const 成员）\n";
+    {
+        alignas(Greeter) std::byte buf[sizeof(Greeter)];
+        Greeter* p1 = ::new (buf) Greeter{"first"};  // NOLINT(cppcoreguidelines-owning-memory)
+        std::cout << "  p1->greeting = " << p1->greeting << "\n";
+        p1->~Greeter();
+
+        Greeter* p2 = ::new (buf) Greeter{"second"};  // NOLINT(cppcoreguidelines-owning-memory)
+        std::cout << "  p2->greeting = " << p2->greeting << "\n";
+        // 注意：原 p1 在新对象生命周期开始后已是悬挂指针；不可再使用。
+        p2->~Greeter();
+    }
+
+    std::cout << "\n[3] std::launder：含 const 成员时刷新指针\n";
+    {
+        alignas(WithConst) std::byte buf[sizeof(WithConst)];
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* p1 = ::new (buf) WithConst{1, 10};
+        std::cout << "  p1: id=" << p1->id << " value=" << p1->value << "\n";
+        p1->~WithConst();
+
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        ::new (buf) WithConst{2, 20};
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        WithConst* p2 = std::launder(reinterpret_cast<WithConst*>(buf));
+        std::cout << "  p2 (laundered): id=" << p2->id << " value=" << p2->value << "\n";
+        p2->~WithConst();
+    }
+
+    std::cout << "\n[4] placement new 用于自管理的小型对象池\n";
+    {
+        Pool pool;
+        auto* a = pool.construct(0, std::string{"slot0"});
+        auto* b = pool.construct(1, std::string{"slot1"});
+        std::cout << "  pool[0]=" << a->greeting << " pool[1]=" << b->greeting << "\n";
+        // Pool 析构时统一释放
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/placement_new.cpp
+++ b/modules/02_lifetime_type_safety/demos/placement_new.cpp
@@ -80,7 +80,8 @@ int main() {
     std::cout << "[1] 在栈上的对齐缓冲区构造 / 析构\n";
     {
         alignas(Greeter) std::byte buf[sizeof(Greeter)];
-        Greeter* p = ::new (buf) Greeter{"hello"};  // NOLINT(cppcoreguidelines-owning-memory)
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* p = ::new (buf) Greeter{"hello"};
         std::cout << "  via p: " << p->greeting << "\n";
         p->~Greeter();
     }
@@ -88,11 +89,13 @@ int main() {
     std::cout << "\n[2] 同一缓冲上构造、析构、再构造（同类型，无 const 成员）\n";
     {
         alignas(Greeter) std::byte buf[sizeof(Greeter)];
-        Greeter* p1 = ::new (buf) Greeter{"first"};  // NOLINT(cppcoreguidelines-owning-memory)
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* p1 = ::new (buf) Greeter{"first"};
         std::cout << "  p1->greeting = " << p1->greeting << "\n";
         p1->~Greeter();
 
-        Greeter* p2 = ::new (buf) Greeter{"second"};  // NOLINT(cppcoreguidelines-owning-memory)
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* p2 = ::new (buf) Greeter{"second"};
         std::cout << "  p2->greeting = " << p2->greeting << "\n";
         // 注意：原 p1 在新对象生命周期开始后已是悬挂指针；不可再使用。
         p2->~Greeter();
@@ -102,14 +105,14 @@ int main() {
     {
         alignas(WithConst) std::byte buf[sizeof(WithConst)];
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        auto* p1 = ::new (buf) WithConst{1, 10};
+        auto* p1 = ::new (buf) WithConst{.id = 1, .value = 10};
         std::cout << "  p1: id=" << p1->id << " value=" << p1->value << "\n";
         p1->~WithConst();
 
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        ::new (buf) WithConst{2, 20};
+        ::new (buf) WithConst{.id = 2, .value = 20};
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        WithConst* p2 = std::launder(reinterpret_cast<WithConst*>(buf));
+        auto* p2 = std::launder(reinterpret_cast<WithConst*>(buf));
         std::cout << "  p2 (laundered): id=" << p2->id << " value=" << p2->value << "\n";
         p2->~WithConst();
     }

--- a/modules/02_lifetime_type_safety/demos/placement_new.cpp
+++ b/modules/02_lifetime_type_safety/demos/placement_new.cpp
@@ -32,8 +32,8 @@ struct Greeter {
 };
 
 // 含 const 成员的类型：替换存储后必须用 std::launder 才能读。
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
 struct WithConst {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
     int const id;
     int value;
 };

--- a/modules/02_lifetime_type_safety/demos/slicing.cpp
+++ b/modules/02_lifetime_type_safety/demos/slicing.cpp
@@ -1,0 +1,110 @@
+// 切片问题（slicing）与基于多态的修复（virtual clone）。
+//
+// 关键点：
+//   - 当用 *基类按值* 接收派生对象时，派生部分被静默丢弃 —— 这就是切片。
+//   - 如果你写 Base& = Derived 然后 Base& = OtherBase，编译器调用的是
+//     Base::operator=，只覆盖基类子对象切片 —— 派生类成员保持不变（同样的坑）。
+//   - C++ Core Guidelines C.67：多态基类应该把 copy/move 设为 protected 或 = delete，
+//     强迫使用 virtual clone() / 指针保留多态。本 demo 给出"反例 → 修复"对照。
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+
+// ---- 反例：可拷贝的多态基类 ----
+struct Person {
+    std::string name;
+
+    explicit Person(std::string n) : name(std::move(n)) {}
+    virtual ~Person() = default;
+    virtual void hello() const {
+        std::cout << "  Person::hello()  name=" << name << "\n";
+    }
+};
+
+struct Student : Person {
+    int student_id;
+
+    Student(std::string n, int id) : Person(std::move(n)), student_id(id) {}
+    void hello() const override {
+        std::cout << "  Student::hello() name=" << name << " id=" << student_id << "\n";
+    }
+};
+
+// ---- 修复：把基类 copy/move 设为 protected，外部用 clone() ----
+class Cloneable {
+public:
+    virtual ~Cloneable() = default;
+    [[nodiscard]] virtual std::unique_ptr<Cloneable> clone() const = 0;
+    virtual void hello() const = 0;
+
+    Cloneable() = default;
+
+protected:
+    Cloneable(Cloneable const&) = default;
+    Cloneable(Cloneable&&) = default;
+    Cloneable& operator=(Cloneable const&) = default;
+    Cloneable& operator=(Cloneable&&) = default;
+};
+
+class StudentCloneable : public Cloneable {
+public:
+    StudentCloneable(std::string n, int id) : name_(std::move(n)), student_id_(id) {}
+
+    [[nodiscard]] std::unique_ptr<Cloneable> clone() const override {
+        return std::make_unique<StudentCloneable>(*this);
+    }
+    void hello() const override {
+        std::cout << "  StudentCloneable::hello() name=" << name_ << " id=" << student_id_ << "\n";
+    }
+
+private:
+    std::string name_;
+    int student_id_;
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 反例：按值传递切片\n";
+    {
+        Student s{"Alice", 1001};
+        // 这里发生切片：p 只持有 Person 子对象 —— 这就是 demo 的核心。
+        // NOLINTNEXTLINE(cppcoreguidelines-slicing,performance-unnecessary-copy-initialization)
+        Person p = s;
+        p.hello();  // -> Person::hello (尽管 hello 是 virtual)
+        s.hello();
+    }
+
+    std::cout << "\n[2] 反例：基类引用赋值，派生成员不变\n";
+    {
+        Student s1{"Alice", 1001};
+        Student s2{"Bob", 2002};
+        Person& p1 = s1;
+        Person const& p2 = s2;
+        p1 = p2;  // 实际调用 Person::operator= —— 只覆盖 name
+        std::cout << "  s1.name=" << s1.name << " s1.id=" << s1.student_id
+                  << "  (id 没被覆盖！)\n";
+    }
+
+    std::cout << "\n[3] 修复：把多态对象保存在指针 / 智能指针里\n";
+    {
+        std::unique_ptr<Person> p = std::make_unique<Student>("Carol", 3003);
+        p->hello();  // -> Student::hello()
+    }
+
+    std::cout << "\n[4] 修复：clone() 模式 —— 在 *正确派生类型* 上完成拷贝\n";
+    {
+        std::unique_ptr<Cloneable> orig = std::make_unique<StudentCloneable>("Dave", 4004);
+        std::unique_ptr<Cloneable> copy = orig->clone();
+        std::cout << "  orig: ";
+        orig->hello();
+        std::cout << "  copy: ";
+        copy->hello();
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/slicing.cpp
+++ b/modules/02_lifetime_type_safety/demos/slicing.cpp
@@ -86,8 +86,7 @@ int main() {
         Person& p1 = s1;
         Person const& p2 = s2;
         p1 = p2;  // 实际调用 Person::operator= —— 只覆盖 name
-        std::cout << "  s1.name=" << s1.name << " s1.id=" << s1.student_id
-                  << "  (id 没被覆盖！)\n";
+        std::cout << "  s1.name=" << s1.name << " s1.id=" << s1.student_id << "  (id 没被覆盖！)\n";
     }
 
     std::cout << "\n[3] 修复：把多态对象保存在指针 / 智能指针里\n";

--- a/modules/02_lifetime_type_safety/demos/storage_duration.cpp
+++ b/modules/02_lifetime_type_safety/demos/storage_duration.cpp
@@ -24,6 +24,9 @@ struct Tag {
     }
 };
 
+// Tag 的 ctor 调 std::cout，clang-tidy 静态分析认为可能抛 ios_base::failure；
+// 这里就是要展示静态对象在 main 之前构造的时机，是 demo 的核心点。
+// NOLINTNEXTLINE(bugprone-throwing-static-initialization,cert-err58-cpp)
 Tag const kGlobalStatic{"static"};
 
 }  // namespace

--- a/modules/02_lifetime_type_safety/demos/storage_reuse.cpp
+++ b/modules/02_lifetime_type_safety/demos/storage_reuse.cpp
@@ -44,11 +44,11 @@ static_assert(!std::is_trivially_destructible_v<NonTrivial>);
 int main() {
     std::cout << "[情况 1] 平凡类型 同类型 替换 —— 旧名字仍可用\n";
     {
-        Trivial t{1, 2};
+        Trivial t{.x = 1, .y = 2};
         Trivial* p = &t;
 
         // 在 t 的存储上构造同类型新对象
-        ::new (&t) Trivial{10, 20};
+        ::new (&t) Trivial{.x = 10, .y = 20};
 
         // 标准允许继续用名字 t 与原指针 p 访问新对象（无需 launder）：
         //   - 类型相同（忽略 cv）

--- a/modules/02_lifetime_type_safety/demos/storage_reuse.cpp
+++ b/modules/02_lifetime_type_safety/demos/storage_reuse.cpp
@@ -1,0 +1,118 @@
+// 存储复用（storage reuse）的可行 / 不可行情形。
+//
+// 文档中的几种情况：
+//   情况 1：相同类型（忽略 cv）替换 + 完全相同存储 —— 旧名字/指针/引用仍有效。
+//   情况 2：被复用对象需是平凡可析构，否则原对象不会被自动析构 —— 必须自己处理。
+//   情况 3：const 完整对象（局部 const T 等）不能被复用 —— 编译器可基于 const
+//          做激进优化，复用后行为未定义。
+//   情况 4：unsigned char / std::byte 数组本身可"承载"其他对象 —— 数组不算结束
+//          生命周期，外层类的生命周期不会被打断。
+//
+// 这里只展示 *合法* 情形并做行为验证；非法情形通过文字注释指出。
+
+#include <cstddef>
+#include <iostream>
+#include <new>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+struct Trivial {
+    int x;
+    int y;
+};
+static_assert(std::is_trivially_destructible_v<Trivial>);
+
+struct NonTrivial {
+    std::string name;
+    explicit NonTrivial(std::string s) : name(std::move(s)) {
+        std::cout << "    NonTrivial::ctor " << name << "\n";
+    }
+    NonTrivial(NonTrivial const&) = delete;
+    NonTrivial(NonTrivial&&) = delete;
+    NonTrivial& operator=(NonTrivial const&) = delete;
+    NonTrivial& operator=(NonTrivial&&) = delete;
+    ~NonTrivial() {
+        std::cout << "    NonTrivial::dtor " << name << "\n";
+    }
+};
+static_assert(!std::is_trivially_destructible_v<NonTrivial>);
+
+}  // namespace
+
+int main() {
+    std::cout << "[情况 1] 平凡类型 同类型 替换 —— 旧名字仍可用\n";
+    {
+        Trivial t{1, 2};
+        Trivial* p = &t;
+
+        // 在 t 的存储上构造同类型新对象
+        ::new (&t) Trivial{10, 20};
+
+        // 标准允许继续用名字 t 与原指针 p 访问新对象（无需 launder）：
+        //   - 类型相同（忽略 cv）
+        //   - 完全相同存储
+        //   - 没有 const 成员
+        std::cout << "  t.x=" << t.x << " t.y=" << t.y << "\n";
+        std::cout << "  p->x=" << p->x << " p->y=" << p->y << "\n";
+    }
+
+    std::cout << "\n[情况 2] 非平凡类型 替换 —— 必须先析构原对象\n";
+    {
+        alignas(NonTrivial) std::byte buf[sizeof(NonTrivial)];
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* a = ::new (buf) NonTrivial{"first"};
+        // 不能直接覆盖：那样 first 持有的 string 堆内存会泄露。
+        a->~NonTrivial();
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        auto* b = ::new (buf) NonTrivial{"second"};
+        std::cout << "  read b: " << b->name << "\n";
+        b->~NonTrivial();
+    }
+
+    std::cout << "\n[情况 3] 局部 const 对象 —— 不可复用其存储（仅文字说明）\n";
+    {
+        // const int kImmortal = 7;
+        // ::new (const_cast<int*>(&kImmortal)) int{42};   // UB！
+        // 编译器会假定 kImmortal 永远是 7，复用属于未定义。
+        std::cout << "  see comments in source\n";
+    }
+
+    std::cout << "\n[情况 4] std::byte 数组承载对象 —— 数组本身不结束生命周期\n";
+    {
+        struct Box {
+            alignas(NonTrivial) std::byte storage[sizeof(NonTrivial)]{};
+            NonTrivial* obj{nullptr};
+
+            Box() = default;
+            Box(Box const&) = delete;
+            Box(Box&&) = delete;
+            Box& operator=(Box const&) = delete;
+            Box& operator=(Box&&) = delete;
+
+            void emplace(std::string s) {
+                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+                obj = ::new (storage) NonTrivial{std::move(s)};
+            }
+            void clear() {
+                if (obj != nullptr) {
+                    obj->~NonTrivial();
+                    obj = nullptr;
+                }
+            }
+            ~Box() {
+                clear();
+            }
+        };
+
+        Box box;
+        box.emplace("inside-byte-buffer");
+        std::cout << "  box.obj->name = " << box.obj->name << "\n";
+        // 此时 storage 数组承载着 NonTrivial；标准规定 storage 本身没结束生命周期，
+        // 因此 box（外层类）也仍处于生命周期内 —— 与情况 4 的承载语义一致。
+        box.clear();
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/variant_visit.cpp
+++ b/modules/02_lifetime_type_safety/demos/variant_visit.cpp
@@ -1,0 +1,99 @@
+// std::variant —— 类型安全的 union；std::visit 实现访问者模式。
+//
+// 关键点：
+//   - variant 同时记录 "当前是哪个 alternative" 与底层数据 —— 取错类型会抛
+//     std::bad_variant_access（指针版 std::get_if 返回 nullptr）。
+//   - variant 默认构造第一个 alternative；用 std::monostate 占位可表达"空"。
+//   - std::visit 对每个 alternative 调用相应重载 —— 编译期穷尽检查，加上
+//     "重载结合体"（overloaded helper）可以非常优雅。
+//   - operator= 抛异常时 variant 可能进入 valueless_by_exception 状态，
+//     index() 返回 variant_npos。
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace {
+
+// 经典的"重载组合"小工具：
+template <class... Fs>
+struct Overloaded : Fs... {
+    using Fs::operator()...;
+};
+// CTAD 让 Overloaded{lambda1, lambda2} 直接成立
+template <class... Fs>
+Overloaded(Fs...) -> Overloaded<Fs...>;
+
+using Shape = std::variant<std::monostate, int, double, std::string>;
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 基本构造与访问\n";
+    {
+        Shape s;  // 默认是 monostate
+        std::cout << "  default index = " << s.index() << "  (monostate)\n";
+
+        s = 42;  // 现在是 int
+        std::cout << "  s.index() = " << s.index() << "  std::get<int>(s) = "
+                  << std::get<int>(s) << '\n';
+
+        s = std::string{"hello"};
+        std::cout << "  s = string\"" << std::get<std::string>(s) << "\"\n";
+    }
+
+    std::cout << "\n[2] holds_alternative / get_if 安全访问\n";
+    {
+        Shape s = 3.14;
+        std::cout << "  holds<double>? " << std::holds_alternative<double>(s) << '\n';
+        if (auto* p = std::get_if<double>(&s); p != nullptr) {
+            std::cout << "  *get_if<double> = " << *p << '\n';
+        }
+        try {
+            std::cout << std::get<int>(s) << '\n';  // 抛 bad_variant_access
+        } catch (std::bad_variant_access const& e) {
+            std::cout << "  bad_variant_access: " << e.what() << '\n';
+        }
+    }
+
+    std::cout << "\n[3] std::visit + overloaded：访问者模式\n";
+    {
+        std::vector<Shape> all;
+        all.emplace_back();             // monostate
+        all.emplace_back(7);            // int
+        all.emplace_back(2.5);          // double
+        all.emplace_back("variant");    // string
+
+        for (auto const& v : all) {
+            std::visit(
+                Overloaded{
+                    [](std::monostate) { std::cout << "  <empty>\n"; },
+                    [](int i) { std::cout << "  int    = " << i << '\n'; },
+                    [](double d) { std::cout << "  double = " << d << '\n'; },
+                    [](std::string const& s) { std::cout << "  string = " << s << '\n'; },
+                },
+                v);
+        }
+    }
+
+    std::cout << "\n[4] in_place 构造 / emplace —— 非可拷贝类型也能装\n";
+    {
+        struct OnlyMovable {
+            int x;
+            explicit OnlyMovable(int v) : x(v) {}
+            OnlyMovable(OnlyMovable const&) = delete;
+            OnlyMovable(OnlyMovable&&) = default;
+            OnlyMovable& operator=(OnlyMovable const&) = delete;
+            OnlyMovable& operator=(OnlyMovable&&) = default;
+            ~OnlyMovable() = default;
+        };
+        std::variant<std::monostate, OnlyMovable> v{std::in_place_type<OnlyMovable>, 99};
+        std::cout << "  in_place OnlyMovable.x = " << std::get<OnlyMovable>(v).x << '\n';
+        v.emplace<OnlyMovable>(100);
+        std::cout << "  after emplace        x = " << std::get<OnlyMovable>(v).x << '\n';
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/demos/variant_visit.cpp
+++ b/modules/02_lifetime_type_safety/demos/variant_visit.cpp
@@ -30,6 +30,10 @@ using Shape = std::variant<std::monostate, int, double, std::string>;
 
 }  // namespace
 
+// std::cout / std::get 在路径分析下"理论上"可能抛 std::ios_base::failure /
+// std::bad_variant_access；在 demo 里我们就是要演示这些异常 —— 让它们离开
+// main 是预期行为，而非 bug。
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main() {
     std::cout << "[1] 基本构造与访问\n";
     {

--- a/modules/02_lifetime_type_safety/demos/variant_visit.cpp
+++ b/modules/02_lifetime_type_safety/demos/variant_visit.cpp
@@ -37,8 +37,8 @@ int main() {
         std::cout << "  default index = " << s.index() << "  (monostate)\n";
 
         s = 42;  // 现在是 int
-        std::cout << "  s.index() = " << s.index() << "  std::get<int>(s) = "
-                  << std::get<int>(s) << '\n';
+        std::cout << "  s.index() = " << s.index() << "  std::get<int>(s) = " << std::get<int>(s)
+                  << '\n';
 
         s = std::string{"hello"};
         std::cout << "  s = string\"" << std::get<std::string>(s) << "\"\n";
@@ -61,20 +61,19 @@ int main() {
     std::cout << "\n[3] std::visit + overloaded：访问者模式\n";
     {
         std::vector<Shape> all;
-        all.emplace_back();             // monostate
-        all.emplace_back(7);            // int
-        all.emplace_back(2.5);          // double
-        all.emplace_back("variant");    // string
+        all.emplace_back();           // monostate
+        all.emplace_back(7);          // int
+        all.emplace_back(2.5);        // double
+        all.emplace_back("variant");  // string
 
         for (auto const& v : all) {
-            std::visit(
-                Overloaded{
-                    [](std::monostate) { std::cout << "  <empty>\n"; },
-                    [](int i) { std::cout << "  int    = " << i << '\n'; },
-                    [](double d) { std::cout << "  double = " << d << '\n'; },
-                    [](std::string const& s) { std::cout << "  string = " << s << '\n'; },
-                },
-                v);
+            std::visit(Overloaded{
+                           [](std::monostate) { std::cout << "  <empty>\n"; },
+                           [](int i) { std::cout << "  int    = " << i << '\n'; },
+                           [](double d) { std::cout << "  double = " << d << '\n'; },
+                           [](std::string const& s) { std::cout << "  string = " << s << '\n'; },
+                       },
+                       v);
         }
     }
 

--- a/modules/02_lifetime_type_safety/demos/virtual_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/demos/virtual_inheritance.cpp
@@ -1,0 +1,92 @@
+// 致命菱形（dreaded diamond）与虚继承。
+//
+// 关键点：
+//   - 普通的菱形继承会让最派生类持有 *两份* 公共基类子对象 —— 既冗余，也无法
+//     直接通过公共基类引用最派生对象（二义性）。
+//   - 虚继承（virtual public Base）让所有派生路径共享同一份基类 —— 二义性消除，
+//     但运行时 / 空间开销更大（虚基偏移表）。
+//   - 虚基类的构造函数由 *最派生类* 直接调用，不能通过中间基类间接调用。
+//   - 一般工程上不鼓励虚继承；混入模式（mixin pattern）通常是更轻巧的替代。
+
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace {
+
+// ---- 反例：未虚继承的菱形 ----
+struct Animal {
+    std::string name;
+    explicit Animal(std::string n) : name(std::move(n)) {
+        std::cout << "  Animal::ctor   name=" << name << "\n";
+    }
+    void breathe() const {
+        std::cout << "  " << name << "::breathe()\n";
+    }
+};
+
+struct Elephant : Animal {
+    using Animal::Animal;
+};
+
+struct Seal : Animal {
+    using Animal::Animal;
+};
+
+struct ElephantSealBad : Elephant, Seal {
+    ElephantSealBad(std::string e_name, std::string s_name)
+        : Elephant(std::move(e_name)), Seal(std::move(s_name)) {}
+};
+
+// ---- 修复：虚继承 ----
+struct AnimalV {
+    std::string name;
+    explicit AnimalV(std::string n) : name(std::move(n)) {
+        std::cout << "  AnimalV::ctor  name=" << name << "\n";
+    }
+    void breathe() const {
+        std::cout << "  " << name << "::breathe()\n";
+    }
+};
+
+struct ElephantV : virtual AnimalV {
+    using AnimalV::AnimalV;
+};
+
+struct SealV : virtual AnimalV {
+    using AnimalV::AnimalV;
+};
+
+struct ElephantSealOK : ElephantV, SealV {
+    // 虚基的构造由最派生类直接调用 —— 否则编译器用默认构造（这里没有默认构造，
+    // 必须显式写）。
+    explicit ElephantSealOK(std::string n)
+        : AnimalV(std::move(n)), ElephantV("ignored"), SealV("ignored") {}
+};
+
+}  // namespace
+
+int main() {
+    std::cout << "[1] 反例：未虚继承 —— 两份基类子对象\n";
+    {
+        ElephantSealBad bad{"Ele", "S"};
+        std::cout << "  bad.Elephant::name = " << bad.Elephant::name << "\n";
+        std::cout << "  bad.Seal::name     = " << bad.Seal::name << "\n";
+        std::cout << "  sizeof(bad) = " << sizeof(bad) << "  (两个 string)\n";
+        // bad.name;        // 编译错误：二义
+        // Animal& a = bad; // 编译错误：二义
+        bad.Elephant::breathe();
+        bad.Seal::breathe();
+    }
+
+    std::cout << "\n[2] 修复：虚继承 —— 共享同一份 AnimalV\n";
+    {
+        ElephantSealOK ok{"OK-seal"};
+        std::cout << "  ok.name = " << ok.name << "\n";  // 不再二义
+        AnimalV& a = ok;
+        a.breathe();
+        std::cout << "  sizeof(ok) = " << sizeof(ok) << "  (含虚基偏移开销)\n";
+    }
+
+    return 0;
+}

--- a/modules/02_lifetime_type_safety/tests/test_aliasing.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_aliasing.cpp
@@ -1,0 +1,86 @@
+// 严格别名规则下哪些"类型双关"是合法的：
+//   - std::byte / unsigned char 指针看任意对象。
+//   - std::bit_cast / std::memcpy 在 trivially copyable 类型间做按位重读。
+//   - 反例：用 reinterpret_cast<float&>(int) 读浮点位 = UB（这里只用文字提示）。
+// 同时覆盖 C++23 std::start_lifetime_as_array（可用时）。
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <version>
+
+#if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
+#  include <memory>
+#endif
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Pixel {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+    std::uint8_t a;
+};
+static_assert(std::is_trivially_copyable_v<Pixel>);
+static_assert(sizeof(Pixel) == 4);
+
+}  // namespace
+
+TEST(Aliasing, ByteViewIsAlwaysAllowed) {
+    Pixel const px{.r = 0x12, .g = 0x34, .b = 0x56, .a = 0x78};
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto const* bytes = reinterpret_cast<std::byte const*>(&px);
+    EXPECT_EQ(std::to_integer<int>(bytes[0]), 0x12);
+    EXPECT_EQ(std::to_integer<int>(bytes[1]), 0x34);
+    EXPECT_EQ(std::to_integer<int>(bytes[2]), 0x56);
+    EXPECT_EQ(std::to_integer<int>(bytes[3]), 0x78);
+}
+
+TEST(Aliasing, BitCastBetweenSameSizedTrivialTypes) {
+    Pixel src{.r = 1, .g = 2, .b = 3, .a = 4};
+    auto packed = std::bit_cast<std::uint32_t>(src);
+    auto round = std::bit_cast<Pixel>(packed);
+    EXPECT_EQ(round.r, 1);
+    EXPECT_EQ(round.g, 2);
+    EXPECT_EQ(round.b, 3);
+    EXPECT_EQ(round.a, 4);
+}
+
+TEST(Aliasing, MemcpyIsTheSafePortableEquivalent) {
+    Pixel src{.r = 0xAA, .g = 0xBB, .b = 0xCC, .a = 0xDD};
+    std::uint32_t packed = 0;
+    std::memcpy(&packed, &src, sizeof(packed));
+    Pixel dst{};
+    std::memcpy(&dst, &packed, sizeof(dst));
+    EXPECT_EQ(dst.r, 0xAA);
+    EXPECT_EQ(dst.g, 0xBB);
+    EXPECT_EQ(dst.b, 0xCC);
+    EXPECT_EQ(dst.a, 0xDD);
+}
+
+#if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
+TEST(Aliasing, StartLifetimeAsArrayMakesObjectsLive) {
+    constexpr std::size_t kCount = 3;
+    auto raw = std::make_unique<std::byte[]>(sizeof(Pixel) * kCount);
+
+    Pixel const seed[kCount]{
+        {.r = 1, .g = 2, .b = 3, .a = 4},
+        {.r = 5, .g = 6, .b = 7, .a = 8},
+        {.r = 9, .g = 10, .b = 11, .a = 12},
+    };
+    std::memcpy(raw.get(), seed, sizeof(seed));
+
+    Pixel* arr = std::start_lifetime_as_array<Pixel>(raw.get(), kCount);
+    EXPECT_EQ(arr[0].r, 1);
+    EXPECT_EQ(arr[1].g, 6);
+    EXPECT_EQ(arr[2].b, 11);
+
+    // 写入也合法
+    arr[0].r = 99;
+    EXPECT_EQ(arr[0].r, 99);
+}
+#endif

--- a/modules/02_lifetime_type_safety/tests/test_aliasing.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_aliasing.cpp
@@ -12,7 +12,7 @@
 #include <version>
 
 #if defined(__cpp_lib_start_lifetime_as) && __cpp_lib_start_lifetime_as >= 202207L
-#  include <memory>
+#include <memory>
 #endif
 
 #include <gtest/gtest.h>

--- a/modules/02_lifetime_type_safety/tests/test_any.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_any.cpp
@@ -1,0 +1,69 @@
+// std::any：装载、any_cast、in_place、reset、swap。
+
+#include <any>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+TEST(Any, DefaultIsEmpty) {
+    std::any a;
+    EXPECT_FALSE(a.has_value());
+}
+
+TEST(Any, HoldsCopyableValueAndAnyCastReadsIt) {
+    std::any a = 42;
+    EXPECT_TRUE(a.has_value());
+    EXPECT_EQ(std::any_cast<int>(a), 42);
+
+    // 引用版 any_cast<T&> 直接修改 *存储* —— 不是拷贝
+    std::any_cast<int&>(a) = 100;
+    EXPECT_EQ(std::any_cast<int>(a), 100);
+}
+
+TEST(Any, WrongValueCastThrowsBadAnyCast) {
+    std::any a = 1LL;  // long long
+    EXPECT_THROW({ static_cast<void>(std::any_cast<int>(a)); }, std::bad_any_cast);
+    EXPECT_EQ(std::any_cast<long long>(a), 1LL);
+}
+
+TEST(Any, PointerCastReturnsNullOnWrongType) {
+    std::any a = std::string{"hi"};
+    EXPECT_EQ(std::any_cast<int>(&a), nullptr);
+    auto const* p = std::any_cast<std::string>(&a);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(*p, "hi");
+}
+
+TEST(Any, ResetMakesItEmpty) {
+    std::any a = std::string{"value"};
+    EXPECT_TRUE(a.has_value());
+    a.reset();
+    EXPECT_FALSE(a.has_value());
+    EXPECT_EQ(std::any_cast<std::string>(&a), nullptr);
+}
+
+TEST(Any, InPlaceTypeAndEmplace) {
+    std::any a{std::in_place_type<std::string>, 5, 'a'};
+    EXPECT_EQ(std::any_cast<std::string>(a), "aaaaa");
+
+    a.emplace<std::string>("emplaced");
+    EXPECT_EQ(std::any_cast<std::string>(a), "emplaced");
+}
+
+TEST(Any, SwapExchangesContents) {
+    std::any a = 1;
+    std::any b = std::string{"hello"};
+    std::swap(a, b);
+    EXPECT_EQ(std::any_cast<std::string>(a), "hello");
+    EXPECT_EQ(std::any_cast<int>(b), 1);
+}
+
+TEST(Any, TypeReturnsTypeInfoOfStoredObject) {
+    std::any a = 3.14;
+    EXPECT_EQ(a.type(), typeid(double));
+    a = std::string{"x"};
+    EXPECT_EQ(a.type(), typeid(std::string));
+    a.reset();
+    EXPECT_EQ(a.type(), typeid(void));
+}

--- a/modules/02_lifetime_type_safety/tests/test_casts.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_casts.cpp
@@ -1,0 +1,83 @@
+// static_cast / const_cast / reinterpret_cast 行为测试。
+// dynamic_cast 单独放在 test_dynamic_cast.cpp。
+
+#include <bit>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+enum class Color : std::uint8_t { Red = 1, Green = 2, Blue = 3 };
+
+struct ImplicitFromInt {
+    int v;
+    ImplicitFromInt(int x) : v(x) {}  // 单参构造可被 static_cast 触发
+};
+
+struct Base {
+    int b{1};
+    virtual ~Base() = default;
+};
+struct Derived : Base {
+    int d{2};
+};
+
+}  // namespace
+
+TEST(StaticCast, NumericNarrowingAndEnums) {
+    int i = static_cast<int>(3.9);
+    EXPECT_EQ(i, 3);  // 截断小数
+
+    auto raw = static_cast<std::uint8_t>(Color::Blue);
+    EXPECT_EQ(raw, 3);
+    EXPECT_EQ(static_cast<Color>(raw), Color::Blue);
+}
+
+TEST(StaticCast, ConstructsViaSingleArgumentConstructor) {
+    auto x = static_cast<ImplicitFromInt>(42);
+    EXPECT_EQ(x.v, 42);
+}
+
+TEST(StaticCast, UpcastIsImplicitDowncastIsExplicit) {
+    Derived d;
+    Base* up = &d;  // 隐式上转
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto* down = static_cast<Derived*>(up);
+    EXPECT_EQ(down->d, 2);
+}
+
+TEST(ConstCast, AddsAndStripsCv) {
+    std::string s{"hello"};
+    auto const& cs = std::as_const(s);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    auto& mut = const_cast<std::string&>(cs);
+    mut[0] = 'H';
+    EXPECT_EQ(s, "Hello");
+}
+
+TEST(ReinterpretCast, PointerToIntAndBack) {
+    int x = 7;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto bits = reinterpret_cast<std::uintptr_t>(&x);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+    int* same = reinterpret_cast<int*>(bits);
+    EXPECT_EQ(same, &x);
+    EXPECT_EQ(*same, 7);
+}
+
+TEST(BitCast, ReinterpretsBitsBetweenSameSizedTrivialTypes) {
+    float f = 1.0F;
+    auto bits = std::bit_cast<std::uint32_t>(f);
+    EXPECT_EQ(bits, 0x3F800000U);
+    auto round = std::bit_cast<float>(bits);
+    EXPECT_EQ(round, 1.0F);
+}
+
+TEST(StaticCastVoid, DiscardsExpressionValue) {
+    int unused = 42;
+    static_cast<void>(unused);  // 等价于 (void)unused; —— 抑制 unused 警告
+    EXPECT_EQ(unused, 42);      // 仅证明对象未被改动
+}

--- a/modules/02_lifetime_type_safety/tests/test_dynamic_cast.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_dynamic_cast.cpp
@@ -1,0 +1,91 @@
+// dynamic_cast 与 RTTI（typeid / type_index）的行为测试。
+
+#include <map>
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Animal {
+    virtual ~Animal() = default;
+    [[nodiscard]] virtual std::string sound() const = 0;
+};
+
+struct Cat : Animal {
+    [[nodiscard]] std::string sound() const override {
+        return "meow";
+    }
+};
+
+struct Dog : Animal {
+    [[nodiscard]] std::string sound() const override {
+        return "woof";
+    }
+};
+
+struct Swims {
+    virtual ~Swims() = default;
+};
+struct Walks {
+    virtual ~Walks() = default;
+};
+struct Frog : Swims, Walks {};
+
+}  // namespace
+
+TEST(DynamicCast, PointerSucceedsForCorrectDerived) {
+    std::unique_ptr<Animal> a = std::make_unique<Dog>();
+    auto* d = dynamic_cast<Dog*>(a.get());
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->sound(), "woof");
+}
+
+TEST(DynamicCast, PointerReturnsNullOnWrongType) {
+    std::unique_ptr<Animal> a = std::make_unique<Dog>();
+    EXPECT_EQ(dynamic_cast<Cat*>(a.get()), nullptr);
+}
+
+TEST(DynamicCast, ReferenceThrowsBadCastOnWrongType) {
+    Cat c;
+    Animal& a = c;
+    EXPECT_THROW({ static_cast<void>(dynamic_cast<Dog&>(a)); }, std::bad_cast);
+}
+
+TEST(DynamicCast, SidecastAcrossSiblingBases) {
+    Frog f;
+    Swims& s = f;
+    auto& w = dynamic_cast<Walks&>(s);
+    EXPECT_EQ(&w, static_cast<Walks*>(&f));
+}
+
+TEST(DynamicCast, ToVoidGivesMostDerivedAddress) {
+    Frog f;
+    Swims& s = f;
+    Walks& w = f;
+    void const* via_swims = dynamic_cast<void const*>(&s);
+    void const* via_walks = dynamic_cast<void const*>(&w);
+    EXPECT_EQ(via_swims, via_walks);
+    EXPECT_EQ(via_swims, static_cast<void const*>(&f));
+}
+
+TEST(Rtti, TypeidComparesActualRuntimeType) {
+    std::unique_ptr<Animal> a = std::make_unique<Dog>();
+    Animal& ref = *a;
+    EXPECT_EQ(typeid(ref), typeid(Dog));
+    EXPECT_NE(typeid(ref), typeid(Cat));
+}
+
+TEST(Rtti, TypeIndexIsHashableAndOrderable) {
+    std::map<std::type_index, std::string> labels;
+    labels.emplace(typeid(int), "int");
+    labels.emplace(typeid(double), "double");
+    labels.emplace(typeid(std::string), "string");
+
+    EXPECT_EQ(labels.at(typeid(int)), "int");
+    EXPECT_EQ(labels.at(typeid(double)), "double");
+    EXPECT_EQ(labels.size(), 3U);
+}

--- a/modules/02_lifetime_type_safety/tests/test_inheritance.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_inheritance.cpp
@@ -1,0 +1,118 @@
+// 多重继承 + using 声明 + 虚继承 + 混入模式的测试。
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// --- using 声明：构造函数继承 + 重载暴露 ---
+struct Holder {
+    std::string value;
+    explicit Holder(std::string v) : value(std::move(v)) {}
+    explicit Holder(int n) : value(static_cast<std::size_t>(n), 'x') {}
+};
+
+struct Wrapper : Holder {
+    using Holder::Holder;
+};
+
+// --- 多重继承同名成员的消歧 ---
+struct A {
+    int who = 1;
+    [[nodiscard]] int whoAmI() const {
+        return who;
+    }
+};
+struct B {
+    int who = 2;
+    [[nodiscard]] int whoAmI() const {
+        return who;
+    }
+};
+struct AB : A, B {
+    using A::whoAmI;  // 选择 A 版本
+};
+
+// --- 致命菱形（虚继承解 vs 不解） ---
+struct Animal {
+    int hp = 100;
+};
+struct Elephant : Animal {};
+struct Seal : Animal {};
+struct ElephantSealBad : Elephant, Seal {};  // 两份 Animal 子对象
+
+struct AnimalV {
+    int hp = 100;
+};
+struct ElephantV : virtual AnimalV {};
+struct SealV : virtual AnimalV {};
+struct ElephantSealOK : ElephantV, SealV {};  // 共享一份 AnimalV
+
+// --- 混入接口 ---
+struct Attacker {
+    virtual ~Attacker() = default;
+    [[nodiscard]] virtual int attackPower() const = 0;
+};
+struct Defender {
+    virtual ~Defender() = default;
+    [[nodiscard]] virtual int defense() const = 0;
+};
+struct Soldier : Attacker, Defender {
+    [[nodiscard]] int attackPower() const override {
+        return 30;
+    }
+    [[nodiscard]] int defense() const override {
+        return 20;
+    }
+};
+
+}  // namespace
+
+TEST(InheritedCtor, UsingExposesAllParentConstructors) {
+    Wrapper a{"abc"};
+    Wrapper b{3};
+    EXPECT_EQ(a.value, "abc");
+    EXPECT_EQ(b.value, "xxx");
+}
+
+TEST(MultipleInheritance, UsingDisambiguatesSameNamedMember) {
+    AB obj{};
+    EXPECT_EQ(obj.whoAmI(), 1);     // using A::whoAmI
+    EXPECT_EQ(obj.A::whoAmI(), 1);  // 显式同样可以
+    EXPECT_EQ(obj.B::whoAmI(), 2);
+}
+
+TEST(Diamond, NonVirtualHasTwoBaseSubobjects) {
+    ElephantSealBad bad{};
+    bad.Elephant::hp = 1;
+    bad.Seal::hp = 2;
+    EXPECT_EQ(bad.Elephant::hp, 1);
+    EXPECT_EQ(bad.Seal::hp, 2);
+    // bad.hp;       // 编译错误：二义
+    // Animal& a=bad;  // 编译错误：二义
+}
+
+TEST(Diamond, VirtualBaseIsShared) {
+    ElephantSealOK ok{};
+    ok.hp = 7;  // 不再二义；只有一份 AnimalV
+    AnimalV& as_animal = ok;
+    EXPECT_EQ(as_animal.hp, 7);
+    ElephantV& as_e = ok;
+    SealV& as_s = ok;
+    EXPECT_EQ(as_e.hp, 7);
+    EXPECT_EQ(as_s.hp, 7);
+}
+
+TEST(MixinPattern, DispatchByCapability) {
+    std::unique_ptr<Attacker> a = std::make_unique<Soldier>();
+    EXPECT_EQ(a->attackPower(), 30);
+
+    // 同一对象通过 Attacker 接口拿到的指针 cast 到兄弟接口 Defender
+    auto* d = dynamic_cast<Defender*>(a.get());
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->defense(), 20);
+}

--- a/modules/02_lifetime_type_safety/tests/test_lifetime.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_lifetime.cpp
@@ -1,6 +1,7 @@
-// 模块 02 的烟雾测试：对象生命周期与引用绑定规则。
+// 模块 02 的核心生命周期测试：作用域析构、引用绑定、const& 延寿、Probe 计数。
 
 #include <string>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -23,6 +24,30 @@ struct Counter {
         --*live;
     }
 };
+
+struct Heavy {
+    static int alive;
+    int x;
+    explicit Heavy(int v) : x(v) {
+        ++alive;
+    }
+    Heavy(Heavy const& o) : x(o.x) {
+        ++alive;
+    }
+    Heavy(Heavy&& o) noexcept : x(o.x) {
+        ++alive;
+    }
+    Heavy& operator=(Heavy const&) = default;
+    Heavy& operator=(Heavy&&) noexcept = default;
+    ~Heavy() {
+        --alive;
+    }
+};
+int Heavy::alive = 0;
+
+[[nodiscard]] Heavy makeHeavy(int v) {
+    return Heavy{v};
+}
 
 }  // namespace
 
@@ -47,4 +72,45 @@ TEST(Lifetime, ReferenceBindsToInitializerNotLater) {
     ref = b;  // 经由 ref 写入 a；不会把 ref 重绑到 b
     EXPECT_EQ(a, "second");
     EXPECT_EQ(&ref, &a);
+}
+
+TEST(Lifetime, ConstRefExtendsTemporaryToBlockEnd) {
+    Heavy::alive = 0;
+    int outer_alive = 0;
+    {
+        Heavy const& h = makeHeavy(42);  // 临时 heavy 寿命延长到块末
+        EXPECT_EQ(h.x, 42);
+        outer_alive = Heavy::alive;
+    }
+    EXPECT_EQ(outer_alive, 1);   // 块内仅 1 个对象活着（无多余拷贝）
+    EXPECT_EQ(Heavy::alive, 0);  // 离开块后被销毁
+}
+
+TEST(Lifetime, RvalueRefAlsoExtendsTemporary) {
+    Heavy::alive = 0;
+    {
+        Heavy&& h = makeHeavy(7);
+        EXPECT_EQ(h.x, 7);
+        EXPECT_EQ(Heavy::alive, 1);
+    }
+    EXPECT_EQ(Heavy::alive, 0);
+}
+
+TEST(Lifetime, TemporaryDiesAtFullExpressionEnd) {
+    Heavy::alive = 0;
+    int snapshot_inside = Heavy::alive;
+    int x = makeHeavy(99).x + 0;  // 临时只活到这条 ; —— 用 +0 强制不被复制延寿
+    snapshot_inside = Heavy::alive;
+    EXPECT_EQ(x, 99);
+    EXPECT_EQ(snapshot_inside, 0);  // 这一行执行时，临时已经析构
+}
+
+TEST(Lifetime, MoveDoesNotDestroySourceImmediately) {
+    Heavy::alive = 0;
+    {
+        Heavy a{1};
+        Heavy b{std::move(a)};  // 移动构造：a 仍然活着，只是状态被转移
+        EXPECT_EQ(Heavy::alive, 2);
+    }
+    EXPECT_EQ(Heavy::alive, 0);
 }

--- a/modules/02_lifetime_type_safety/tests/test_lifetime_extension.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_lifetime_extension.cpp
@@ -1,0 +1,86 @@
+// const& / && 临时对象延寿；以及"绕一圈就丢失延寿"的几种情形。
+
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Counted {
+    static int alive;
+    int x;
+    explicit Counted(int v) : x(v) {
+        ++alive;
+    }
+    Counted(Counted const& o) : x(o.x) {
+        ++alive;
+    }
+    Counted(Counted&& o) noexcept : x(o.x) {
+        ++alive;
+    }
+    Counted& operator=(Counted const&) = default;
+    Counted& operator=(Counted&&) noexcept = default;
+    ~Counted() {
+        --alive;
+    }
+};
+int Counted::alive = 0;
+
+[[nodiscard]] Counted makeCounted(int v) {
+    return Counted{v};
+}
+
+struct Wrapper {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+    Counted const& ref;
+};
+
+}  // namespace
+
+TEST(Extension, ConstRefHoldsTemporaryUntilBlockEnd) {
+    Counted::alive = 0;
+    {
+        Counted const& c = makeCounted(11);
+        EXPECT_EQ(c.x, 11);
+        EXPECT_EQ(Counted::alive, 1);
+    }
+    EXPECT_EQ(Counted::alive, 0);
+}
+
+TEST(Extension, RvalueRefAlsoExtends) {
+    Counted::alive = 0;
+    {
+        Counted&& c = makeCounted(22);
+        EXPECT_EQ(c.x, 22);
+        EXPECT_EQ(Counted::alive, 1);
+    }
+    EXPECT_EQ(Counted::alive, 0);
+}
+
+TEST(Extension, ConstRefValueReadableInExtendedScope) {
+    // const& 直接绑定函数返回的临时：值仍然可读、生命周期到引用作用域结束。
+    Counted::alive = 0;
+    int x_at_inner = 0;
+    {
+        Counted const& c = makeCounted(33);
+        x_at_inner = c.x;
+        EXPECT_GE(Counted::alive, 1);  // 至少自己活着
+    }
+    EXPECT_EQ(x_at_inner, 33);
+    EXPECT_EQ(Counted::alive, 0);
+    (void)Wrapper{Counted{1}};  // 编译验证：聚合体可绑定到引用成员（运行期不读 ref）
+}
+
+TEST(Extension, MovingFromConstRefDoesNotKillSource) {
+    Counted::alive = 0;
+    {
+        Counted const& c = makeCounted(7);
+        // const&& 不能用 std::move 改变绑定 —— 这只是 *引用* 的副本
+        Counted const& c2 = c;
+        EXPECT_EQ(Counted::alive, 1);
+        EXPECT_EQ(&c, &c2);
+        EXPECT_EQ(c2.x, 7);
+    }
+    EXPECT_EQ(Counted::alive, 0);
+}

--- a/modules/02_lifetime_type_safety/tests/test_placement_new.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_placement_new.cpp
@@ -1,0 +1,98 @@
+// placement new 与 std::launder 的行为测试。
+
+#include <cstddef>
+#include <new>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Tracker {
+    static int alive;
+    std::string label;
+
+    explicit Tracker(std::string s) : label(std::move(s)) {
+        ++alive;
+    }
+    Tracker(Tracker const&) = delete;
+    Tracker(Tracker&&) = delete;
+    Tracker& operator=(Tracker const&) = delete;
+    Tracker& operator=(Tracker&&) = delete;
+    ~Tracker() {
+        --alive;
+    }
+};
+int Tracker::alive = 0;
+
+struct WithConstField {
+    int const id;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    int value;
+};
+
+}  // namespace
+
+TEST(PlacementNew, ConstructsAndDestroysInExternalBuffer) {
+    Tracker::alive = 0;
+    alignas(Tracker) std::byte buf[sizeof(Tracker)];
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        Tracker* p = ::new (buf) Tracker{"hello"};
+        EXPECT_EQ(Tracker::alive, 1);
+        EXPECT_EQ(p->label, "hello");
+        p->~Tracker();
+    }
+    EXPECT_EQ(Tracker::alive, 0);
+}
+
+TEST(PlacementNew, ReuseBufferForSameType) {
+    Tracker::alive = 0;
+    alignas(Tracker) std::byte buf[sizeof(Tracker)];
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    Tracker* p1 = ::new (buf) Tracker{"first"};
+    EXPECT_EQ(p1->label, "first");
+    p1->~Tracker();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    Tracker* p2 = ::new (buf) Tracker{"second"};
+    EXPECT_EQ(p2->label, "second");
+    EXPECT_EQ(Tracker::alive, 1);
+    p2->~Tracker();
+    EXPECT_EQ(Tracker::alive, 0);
+}
+
+TEST(PlacementNew, ForgettingExplicitDtorWouldLeak) {
+    // 这条测试只在 *逻辑上* 提醒：忘记 obj.~T() 会把 string 持有的堆缓冲泄漏。
+    // 这里用计数器证实：若我们不调析构，alive 不会减。
+    Tracker::alive = 0;
+    {
+        alignas(Tracker) std::byte buf[sizeof(Tracker)];
+        // NOLINTNEXTLINE(bugprone-unused-return-value)
+        ::new (buf) Tracker{"leak-on-purpose"};
+        EXPECT_EQ(Tracker::alive, 1);
+        // 故意不调用 ~Tracker —— 注意：此举仅作教学；实际产线代码必须显式析构。
+        // 我们手动补回，避免 ASan / 静态计数残留。
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        std::launder(reinterpret_cast<Tracker*>(buf))->~Tracker();
+    }
+    EXPECT_EQ(Tracker::alive, 0);
+}
+
+TEST(PlacementNew, LaunderRequiredAfterReuseWithConstMember) {
+    alignas(WithConstField) std::byte buf[sizeof(WithConstField)];
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    auto* p1 = ::new (buf) WithConstField{.id = 1, .value = 100};
+    EXPECT_EQ(p1->id, 1);
+    EXPECT_EQ(p1->value, 100);
+    p1->~WithConstField();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    ::new (buf) WithConstField{.id = 2, .value = 200};
+    // 旧指针 p1 在含 const 成员时不可再用；必须 std::launder 出新的指针
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto* p2 = std::launder(reinterpret_cast<WithConstField*>(buf));
+    EXPECT_EQ(p2->id, 2);
+    EXPECT_EQ(p2->value, 200);
+    p2->~WithConstField();
+}

--- a/modules/02_lifetime_type_safety/tests/test_placement_new.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_placement_new.cpp
@@ -38,7 +38,7 @@ TEST(PlacementNew, ConstructsAndDestroysInExternalBuffer) {
     alignas(Tracker) std::byte buf[sizeof(Tracker)];
     {
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        Tracker* p = ::new (buf) Tracker{"hello"};
+        auto* p = ::new (buf) Tracker{"hello"};
         EXPECT_EQ(Tracker::alive, 1);
         EXPECT_EQ(p->label, "hello");
         p->~Tracker();
@@ -50,12 +50,12 @@ TEST(PlacementNew, ReuseBufferForSameType) {
     Tracker::alive = 0;
     alignas(Tracker) std::byte buf[sizeof(Tracker)];
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    Tracker* p1 = ::new (buf) Tracker{"first"};
+    auto* p1 = ::new (buf) Tracker{"first"};
     EXPECT_EQ(p1->label, "first");
     p1->~Tracker();
 
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    Tracker* p2 = ::new (buf) Tracker{"second"};
+    auto* p2 = ::new (buf) Tracker{"second"};
     EXPECT_EQ(p2->label, "second");
     EXPECT_EQ(Tracker::alive, 1);
     p2->~Tracker();

--- a/modules/02_lifetime_type_safety/tests/test_slicing.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_slicing.cpp
@@ -1,0 +1,94 @@
+// 切片问题与 clone() 模式。
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Person {
+    std::string name;
+
+    explicit Person(std::string n) : name(std::move(n)) {}
+    Person(Person const&) = default;
+    Person(Person&&) = default;
+    Person& operator=(Person const&) = default;
+    Person& operator=(Person&&) = default;
+    virtual ~Person() = default;
+    [[nodiscard]] virtual std::string describe() const {
+        return "Person(" + name + ")";
+    }
+};
+
+struct Student : Person {
+    int student_id;
+
+    Student(std::string n, int id) : Person(std::move(n)), student_id(id) {}
+    [[nodiscard]] std::string describe() const override {
+        return "Student(" + name + "," + std::to_string(student_id) + ")";
+    }
+};
+
+class Cloneable {
+public:
+    Cloneable() = default;
+    virtual ~Cloneable() = default;
+    [[nodiscard]] virtual std::unique_ptr<Cloneable> clone() const = 0;
+    [[nodiscard]] virtual std::string describe() const = 0;
+
+protected:
+    Cloneable(Cloneable const&) = default;
+    Cloneable(Cloneable&&) = default;
+    Cloneable& operator=(Cloneable const&) = default;
+    Cloneable& operator=(Cloneable&&) = default;
+};
+
+class StudentCloneable : public Cloneable {
+public:
+    StudentCloneable(std::string n, int id) : name_(std::move(n)), student_id_(id) {}
+
+    [[nodiscard]] std::unique_ptr<Cloneable> clone() const override {
+        return std::make_unique<StudentCloneable>(*this);
+    }
+    [[nodiscard]] std::string describe() const override {
+        return "Student(" + name_ + "," + std::to_string(student_id_) + ")";
+    }
+
+private:
+    std::string name_;
+    int student_id_;
+};
+
+}  // namespace
+
+TEST(Slicing, AssignByValueDropsDerivedPart) {
+    Student s{"Alice", 1001};
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing,performance-unnecessary-copy-initialization)
+    Person p = s;  // 切片：p 是 Person，不再持有 student_id
+    EXPECT_EQ(p.describe(), "Person(Alice)");
+    EXPECT_EQ(s.describe(), "Student(Alice,1001)");
+}
+
+TEST(Slicing, AssignThroughBaseRefOnlyTouchesBaseSubobject) {
+    Student s1{"Alice", 1001};
+    Student s2{"Bob", 2002};
+    Person& base_ref = s1;
+    // NOLINTNEXTLINE(cppcoreguidelines-slicing)
+    base_ref = s2;  // 实际调用 Person::operator=，只覆盖 name；id 保留
+    EXPECT_EQ(s1.name, "Bob");
+    EXPECT_EQ(s1.student_id, 1001);
+}
+
+TEST(Slicing, PolymorphicPointerKeepsDerivedBehavior) {
+    std::unique_ptr<Person> p = std::make_unique<Student>("Carol", 3003);
+    EXPECT_EQ(p->describe(), "Student(Carol,3003)");
+}
+
+TEST(Slicing, CloneFixSurvivesPolymorphicCopy) {
+    std::unique_ptr<Cloneable> orig = std::make_unique<StudentCloneable>("Dave", 4004);
+    auto copy = orig->clone();
+    EXPECT_EQ(copy->describe(), orig->describe());
+    EXPECT_NE(copy.get(), orig.get());  // 不同对象
+}

--- a/modules/02_lifetime_type_safety/tests/test_storage_reuse.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_storage_reuse.cpp
@@ -1,0 +1,105 @@
+// 存储复用：平凡类型 vs 非平凡类型；byte 数组承载对象。
+
+#include <cstddef>
+#include <new>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct Trivial {
+    int x;
+    int y;
+};
+static_assert(std::is_trivially_destructible_v<Trivial>);
+static_assert(std::is_trivially_copyable_v<Trivial>);
+
+struct NonTrivial {
+    static int alive;
+    std::string s;
+    explicit NonTrivial(std::string v) : s(std::move(v)) {
+        ++alive;
+    }
+    NonTrivial(NonTrivial const&) = delete;
+    NonTrivial(NonTrivial&&) = delete;
+    NonTrivial& operator=(NonTrivial const&) = delete;
+    NonTrivial& operator=(NonTrivial&&) = delete;
+    ~NonTrivial() {
+        --alive;
+    }
+};
+int NonTrivial::alive = 0;
+
+}  // namespace
+
+TEST(StorageReuse, TrivialTypeNameIsValidAfterPlacementNewSameType) {
+    Trivial t{.x = 1, .y = 2};
+    Trivial* p = &t;
+
+    // 在 t 的存储上重新构造同类型对象：t 与 p 仍然合法（无须 launder）
+    ::new (&t) Trivial{.x = 10, .y = 20};
+    EXPECT_EQ(t.x, 10);
+    EXPECT_EQ(t.y, 20);
+    EXPECT_EQ(p->x, 10);
+    EXPECT_EQ(p->y, 20);
+}
+
+TEST(StorageReuse, NonTrivialNeedsManualDestructionBeforeReuse) {
+    NonTrivial::alive = 0;
+    alignas(NonTrivial) std::byte buf[sizeof(NonTrivial)];
+
+    auto* a = ::new (buf) NonTrivial{"first"};
+    EXPECT_EQ(NonTrivial::alive, 1);
+    a->~NonTrivial();
+
+    auto* b = ::new (buf) NonTrivial{"second"};
+    EXPECT_EQ(NonTrivial::alive, 1);  // 同时只有 1 个活着 —— 我们手工管理
+    EXPECT_EQ(b->s, "second");
+
+    b->~NonTrivial();
+    EXPECT_EQ(NonTrivial::alive, 0);
+}
+
+TEST(StorageReuse, ByteArrayCarriesObjectWithoutEndingItsLifetime) {
+    NonTrivial::alive = 0;
+    struct Box {
+        alignas(NonTrivial) std::byte storage[sizeof(NonTrivial)]{};
+        NonTrivial* obj{nullptr};
+
+        Box() = default;
+        Box(Box const&) = delete;
+        Box(Box&&) = delete;
+        Box& operator=(Box const&) = delete;
+        Box& operator=(Box&&) = delete;
+
+        void emplace(std::string s) {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+            obj = ::new (storage) NonTrivial{std::move(s)};
+        }
+        void clear() {
+            if (obj != nullptr) {
+                obj->~NonTrivial();
+                obj = nullptr;
+            }
+        }
+        ~Box() {
+            clear();
+        }
+    };
+
+    {
+        Box box;
+        box.emplace("inside");
+        EXPECT_EQ(NonTrivial::alive, 1);
+        EXPECT_EQ(box.obj->s, "inside");
+        box.clear();
+        EXPECT_EQ(NonTrivial::alive, 0);
+        // 即便我们刚刚 clear，box 自身仍然合法 —— byte 数组不结束生命周期
+        box.emplace("re-emplaced");
+        EXPECT_EQ(box.obj->s, "re-emplaced");
+    }
+    EXPECT_EQ(NonTrivial::alive, 0);
+}

--- a/modules/02_lifetime_type_safety/tests/test_variant.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_variant.cpp
@@ -49,17 +49,18 @@ TEST(Variant, GetWrongAlternativeThrows) {
 
 TEST(Variant, VisitDispatchesOnActiveAlternative) {
     std::vector<std::variant<int, double, std::string>> all{
-        1, 2.5, std::string{"x"},
+        1,
+        2.5,
+        std::string{"x"},
     };
     std::vector<std::string> tags;
     for (auto const& v : all) {
-        std::visit(
-            Overloaded{
-                [&](int) { tags.emplace_back("int"); },
-                [&](double) { tags.emplace_back("double"); },
-                [&](std::string const&) { tags.emplace_back("string"); },
-            },
-            v);
+        std::visit(Overloaded{
+                       [&](int) { tags.emplace_back("int"); },
+                       [&](double) { tags.emplace_back("double"); },
+                       [&](std::string const&) { tags.emplace_back("string"); },
+                   },
+                   v);
     }
     ASSERT_EQ(tags.size(), 3U);
     EXPECT_EQ(tags[0], "int");

--- a/modules/02_lifetime_type_safety/tests/test_variant.cpp
+++ b/modules/02_lifetime_type_safety/tests/test_variant.cpp
@@ -1,0 +1,96 @@
+// std::variant：基本 API、std::visit、monostate、emplace。
+
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+template <class... Fs>
+struct Overloaded : Fs... {
+    using Fs::operator()...;
+};
+template <class... Fs>
+Overloaded(Fs...) -> Overloaded<Fs...>;
+
+}  // namespace
+
+TEST(Variant, DefaultsToFirstAlternative) {
+    std::variant<int, std::string> v;
+    EXPECT_EQ(v.index(), 0U);
+    EXPECT_TRUE(std::holds_alternative<int>(v));
+    EXPECT_EQ(std::get<int>(v), 0);
+}
+
+TEST(Variant, MonostateAsExplicitEmpty) {
+    std::variant<std::monostate, int, std::string> v;
+    EXPECT_EQ(v.index(), 0U);
+    EXPECT_TRUE(std::holds_alternative<std::monostate>(v));
+}
+
+TEST(Variant, AssignSwitchesActiveAlternative) {
+    std::variant<int, std::string> v = 1;
+    EXPECT_TRUE(std::holds_alternative<int>(v));
+    v = std::string{"two"};
+    EXPECT_TRUE(std::holds_alternative<std::string>(v));
+    EXPECT_EQ(std::get<std::string>(v), "two");
+}
+
+TEST(Variant, GetWrongAlternativeThrows) {
+    std::variant<int, double> v = 3.14;
+    EXPECT_THROW({ static_cast<void>(std::get<int>(v)); }, std::bad_variant_access);
+    EXPECT_EQ(std::get_if<int>(&v), nullptr);
+    ASSERT_NE(std::get_if<double>(&v), nullptr);
+    EXPECT_DOUBLE_EQ(*std::get_if<double>(&v), 3.14);
+}
+
+TEST(Variant, VisitDispatchesOnActiveAlternative) {
+    std::vector<std::variant<int, double, std::string>> all{
+        1, 2.5, std::string{"x"},
+    };
+    std::vector<std::string> tags;
+    for (auto const& v : all) {
+        std::visit(
+            Overloaded{
+                [&](int) { tags.emplace_back("int"); },
+                [&](double) { tags.emplace_back("double"); },
+                [&](std::string const&) { tags.emplace_back("string"); },
+            },
+            v);
+    }
+    ASSERT_EQ(tags.size(), 3U);
+    EXPECT_EQ(tags[0], "int");
+    EXPECT_EQ(tags[1], "double");
+    EXPECT_EQ(tags[2], "string");
+}
+
+TEST(Variant, EmplaceConstructsInPlace) {
+    std::variant<std::monostate, std::string> v;
+    v.emplace<std::string>(5, '*');  // "*****"
+    EXPECT_EQ(std::get<std::string>(v), "*****");
+}
+
+TEST(Variant, InPlaceTypeForMoveOnly) {
+    struct MoveOnly {
+        int x;
+        explicit MoveOnly(int v) : x(v) {}
+        MoveOnly(MoveOnly const&) = delete;
+        MoveOnly(MoveOnly&&) = default;
+        MoveOnly& operator=(MoveOnly const&) = delete;
+        MoveOnly& operator=(MoveOnly&&) = default;
+        ~MoveOnly() = default;
+    };
+    std::variant<std::monostate, MoveOnly> v{std::in_place_type<MoveOnly>, 7};
+    EXPECT_EQ(std::get<MoveOnly>(v).x, 7);
+}
+
+TEST(Variant, IndexedAccessForRepeatedTypes) {
+    std::variant<int, int, std::string> v{std::in_place_index<1>, 42};
+    EXPECT_EQ(v.index(), 1U);
+    EXPECT_EQ(std::get<1>(v), 42);
+    ASSERT_NE(std::get_if<1>(&v), nullptr);
+    EXPECT_EQ(std::get_if<0>(&v), nullptr);
+}

--- a/modules/05_containers_ranges_p1/tests/test_unordered.cpp
+++ b/modules/05_containers_ranges_p1/tests/test_unordered.cpp
@@ -63,11 +63,11 @@ TEST(UnorderedMap, BucketInterface) {
 
 TEST(UnorderedSet, CustomHashFunctor) {
     std::unordered_set<Point, PointHash> s;
-    s.insert({1, 2});
-    s.insert({3, 4});
-    s.insert({1, 2});  // 重复 → 不插入
+    s.insert({.x = 1, .y = 2});
+    s.insert({.x = 3, .y = 4});
+    s.insert({.x = 1, .y = 2});  // 重复 → 不插入
     EXPECT_EQ(s.size(), 2U);
-    EXPECT_TRUE(s.contains(Point{1, 2}));
+    EXPECT_TRUE(s.contains(Point{.x = 1, .y = 2}));
 }
 
 TEST(UnorderedMultimap, EqualityIgnoresOrderWithinKey) {


### PR DESCRIPTION
## Summary

按 `modules/02_lifetime_type_safety/docs/zh-CN.md` 文档脉络补齐模块 02 的 demo 与 test。

- **Demos（13 新 + 1 已有 storage_duration）**
  - 生命周期：`lifetime_extension` / `dangling_pitfalls` / `placement_new` / `storage_reuse` / `byte_storage`
  - 继承扩展：`slicing`（+ clone 模式）/ `multiple_inheritance`（using 声明）/ `virtual_inheritance`（致命菱形）/ `mixin_pattern`
  - 类型安全：`casts_overview`（4 种 cast + `std::bit_cast`）/ `dynamic_cast_rtti` / `variant_visit`（+ overloaded helper）/ `any_demo`
- **Tests（10 新 + `test_lifetime` 扩展，共 59 GTest 用例）**
  - 覆盖作用域析构、`const&`/`&&` 延寿、placement new + `std::launder`、存储复用、严格别名豁免、切片与 clone、`using` / 虚继承 / 混入派遣、四种 cast 边界、`dynamic_cast` 侧向转换 + RTTI、`variant` + `visit`、`any`。

## 工程要点

- 故意 UB 路径用 `#if defined(MCPP_DEMONSTRATE_UB)` 隔离，避免触发 `-Werror` / clang-tidy 假警报。
- C++23 `start_lifetime_as_array` 用 `__cpp_lib_start_lifetime_as` feature test 兜底（GCC 13 / Apple Clang 兼容）。
- 严守 `.clang-tidy` 命名规则（函数 camelBack / 结构体 CamelCase / 常量 kCamelCase）。
- 顶层 CMakeLists 不动 —— 仅模块本地 `CMakeLists.txt` 注册新 target。

## Test plan

- [x] `cmake --build --preset clang-cl-relwithdebinfo` 14 demo + 11 test 全部编译通过
- [x] `ctest --preset clang-cl-relwithdebinfo -R '^02_lifetime'` —— 59/59 全绿
- [x] `cmake --build --preset clang-cl-relwithdebinfo --target format-check` —— 通过
- [ ] CI 矩阵（GCC / Clang / MSVC / clang-cl / MinGW / macOS）+ lint job 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)