### PR TITLE
docs: fix documentation drift across README and module guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ module (demos + optional unit tests), buildable on gcc, clang, and MSVC.
 
 ```
 ModernCpp/
-├── CMakeLists.txt            # 顶层 / top-level
-├── CMakePresets.json         # gcc/clang/msvc presets
-├── .clangd, .clang-format    # clangd 统一代码风格
-├── vcpkg.json, conanfile.txt # 依赖清单（二选一）
-├── cmake/                    # CompilerWarnings / ModuleHelpers / Dependencies
+├── CMakeLists.txt              # 顶层 / top-level
+├── CMakePresets.json           # gcc/clang/msvc/mingw presets
+├── .clangd                     # clangd 配置
+├── .clang-format               # 代码格式化规则
+├── .clang-tidy                 # 静态检查规则
+├── vcpkg.json                  # vcpkg 依赖清单
+├── conanfile.txt               # Conan 依赖清单（与 vcpkg 二选一）
+├── conan/profiles/             # Conan host profile（per 平台/工具链）
+├── cmake/                      # CompilerWarnings / CompilerSanitizers /
+│                               # ModuleHelpers / Dependencies /
+│                               # RunClangFormat / RunClangTidy
 └── modules/
     └── NN_shortname/
         ├── CMakeLists.txt
@@ -46,8 +52,9 @@ ModernCpp/
 
 部分模块用到的 C++23 ranges/generator API 需要 GCC 15 / libstdc++-15，所以推荐
 Ubuntu 25.10 或更新（apt 默认仓库就带 g++-15、clang-20）。Ubuntu 24.04 LTS 上的 g++-13
-跑模块 0–5 没问题，但 06 起的 ranges/generator demo 会缺 API。CI 在 `ubuntu:25.10`
-容器里跑，本地想完全对齐就用同款 docker 镜像，或者给 24.04 加 `ubuntu-toolchain-r` ppa。
+跑模块 0–5 没问题，但 06 起的 ranges/generator demo 会缺 API。CI 在 `archlinux:base-devel`
+容器里跑（滚动发行版，当前 GCC 15.x / Clang 22.x），本地想完全对齐可用同款 Arch 容器，
+或者给 Ubuntu 24.04 加 `ubuntu-toolchain-r` ppa。
 
 ```bash
 # 1) 工具链（Ubuntu 25.10+）
@@ -354,7 +361,7 @@ ctest --preset msvc-release
 
 ### 格式化 / Formatting
 
-仓库根的 `.clang-format` 控制 C/C++ 风格，CI 用 `clang-format-20 --dry-run --Werror` 校验。
+仓库根的 `.clang-format` 控制 C/C++ 风格，CI 用 `clang-format --dry-run --Werror`（Arch rolling，当前 LLVM 22.x）校验。
 本地一键修复 / 校验：
 
 ```bash
@@ -362,7 +369,7 @@ cmake --build --preset gcc-debug --target format        # 原地修复全部 .cp
 cmake --build --preset gcc-debug --target format-check  # 仅 dry-run，与 CI 行为一致
 ```
 
-需要 `clang-format`（推荐 18+）在 PATH 中；CMake 配置时 `find_program` 检测不到就跳过这两个 target。
+需要 `clang-format`（推荐 22+，与 CI 的 Arch rolling LLVM 对齐）在 PATH 中；CMake 配置时 `find_program` 检测不到就跳过这两个 target。
 非 C/C++ 文件（CMake、JSON、YAML、Markdown）的缩进由根目录 `.editorconfig` 兜底，VS Code / JetBrains
 等主流 IDE 会自动识别。
 
@@ -410,16 +417,16 @@ GitHub Actions（`.github/workflows/ci.yml`）在每次 push 与 PR 上跑一个
 
 | Job | 平台 | 内容 |
 | --- | --- | --- |
-| `linux-gcc`        | ubuntu-24.04 host + `ubuntu:25.10` container | GCC 15 + vcpkg + `gcc-relwithdebinfo` |
-| `linux-clang`      | ubuntu-24.04 host + `ubuntu:25.10` container | Clang 20 + libstdc++-15 + `clang-relwithdebinfo` |
-| `linux-gcc-asan`   | ubuntu-24.04 host + `ubuntu:25.10` container | GCC 15 + `gcc-debug` + `MCPP_ENABLE_SANITIZERS=ON`（ASan + UBSan） |
-| `linux-gcc-conan`  | ubuntu-24.04 host + `ubuntu:25.10` container | GCC 15 + Conan 2.x + `gcc-relwithdebinfo-conan` |
+| `linux-gcc`        | ubuntu-24.04 host + `archlinux:base-devel` container | GCC（rolling，当前 15.x）+ vcpkg + `gcc-relwithdebinfo` |
+| `linux-clang`      | ubuntu-24.04 host + `archlinux:base-devel` container | Clang（rolling，当前 22.x）+ libstdc++ + `clang-relwithdebinfo` |
+| `linux-gcc-asan`   | ubuntu-24.04 host + `archlinux:base-devel` container | GCC + `gcc-debug` + `MCPP_ENABLE_SANITIZERS=ON`（ASan + UBSan） |
+| `linux-gcc-conan`  | ubuntu-24.04 host + `archlinux:base-devel` container | GCC + Conan 2.x + `gcc-relwithdebinfo-conan` |
 | `windows-msvc`     | windows-2022 | MSVC (VS 2022) + `msvc-relwithdebinfo` |
 | `windows-clang-cl` | windows-2022 | LLVM clang-cl + `clang-cl-relwithdebinfo` |
 | `windows-msvc-asan`| windows-2022 | MSVC + `msvc-debug` + `MCPP_ENABLE_SANITIZERS=ON`（MSVC ASan） |
 | `windows-mingw-gcc`| windows-2022 | MSYS2 UCRT64 GCC + `mingw-gcc-relwithdebinfo`（验证非-MSVC ABI 路径 + `x64-mingw-dynamic` triplet） |
 | `macos-clang`      | macos-14     | Apple Clang + `clang-relwithdebinfo`（验证 `_clang` preset 的 Darwin 分支） |
-| `lint`             | ubuntu-24.04 host + `ubuntu:25.10` container | `clang-format-20 --dry-run --Werror` + `clang-tidy-20`（target `format-check` / `tidy-check`） |
+| `lint`             | ubuntu-24.04 host + `archlinux:base-devel` container | `clang-format --dry-run --Werror` + `clang-tidy`（target `format-check` / `tidy-check`，LLVM rolling，当前 22.x） |
 
 任一 job 失败即阻止 PR 合并。该矩阵不仅覆盖三种主流编译器，还把 sanitizer、Conan、MinGW、clang-cl、macOS 都纳入主线，避免某条路径"名义支持但长期未跑"。
 
@@ -429,22 +436,22 @@ GitHub Actions（`.github/workflows/ci.yml`）在每次 push 与 PR 上跑一个
 
 ## Module Index / 模块索引
 
-图例：✅ 已落地 demos/tests · ⚠️ WIP（仅文档，无 demos/tests）。
+所有模块均已落地 demos + tests。
 
 | # | 模块 | 主题 | 状态 |
 | - | --- | --- | --- |
 | 01 | [`modules/01_basics`](modules/01_basics/) | 基础复习与扩展 / Basics Review & Extensions | ✅ |
 | 02 | [`modules/02_lifetime_type_safety`](modules/02_lifetime_type_safety/) | 生命周期与类型安全 / Lifetime & Type Safety | ✅ |
-| 03 | [`modules/03_multi_file`](modules/03_multi_file/) | 多文件编程 / Multi-file Programming | ⚠️ WIP |
-| 04 | [`modules/04_streams_strings`](modules/04_streams_strings/) | 流与字符串 / Streams & Strings | ⚠️ WIP |
-| 05 | [`modules/05_containers_ranges_p1`](modules/05_containers_ranges_p1/) | 容器、ranges 与算法 Part 1 | ⚠️ WIP |
-| 06 | [`modules/06_containers_ranges_p2`](modules/06_containers_ranges_p2/) | 容器、ranges 与算法 Part 2 | ⚠️ WIP |
-| 07 | [`modules/07_value_categories`](modules/07_value_categories/) | 值分类与移动语义 / Value Categories & Move Semantics | ⚠️ WIP |
-| 08 | [`modules/08_templates_basics`](modules/08_templates_basics/) | 模板基础与移动语义 / Templates Basics & Move Semantics | ⚠️ WIP |
-| 09 | [`modules/09_templates_advanced`](modules/09_templates_advanced/) | 模板进阶 / Advanced Templates | ⚠️ WIP |
-| 10 | [`modules/10_memory`](modules/10_memory/) | 内存管理 / Memory Management | ⚠️ WIP |
+| 03 | [`modules/03_multi_file`](modules/03_multi_file/) | 多文件编程 / Multi-file Programming | ✅ |
+| 04 | [`modules/04_streams_strings`](modules/04_streams_strings/) | 流与字符串 / Streams & Strings | ✅ |
+| 05 | [`modules/05_containers_ranges_p1`](modules/05_containers_ranges_p1/) | 容器、ranges 与算法 Part 1 | ✅ |
+| 06 | [`modules/06_containers_ranges_p2`](modules/06_containers_ranges_p2/) | 容器、ranges 与算法 Part 2 | ✅ |
+| 07 | [`modules/07_value_categories`](modules/07_value_categories/) | 值分类与移动语义 / Value Categories & Move Semantics | ✅ |
+| 08 | [`modules/08_templates_basics`](modules/08_templates_basics/) | 模板基础与移动语义 / Templates Basics & Move Semantics | ✅ |
+| 09 | [`modules/09_templates_advanced`](modules/09_templates_advanced/) | 模板进阶 / Advanced Templates | ✅ |
+| 10 | [`modules/10_memory`](modules/10_memory/) | 内存管理 / Memory Management | ✅ |
 | 11 | [`modules/11_error_handling`](modules/11_error_handling/) | 错误处理 / Error Handling | ✅ |
 | 12 | [`modules/12_threading`](modules/12_threading/) | 多线程（新）/ Threading (Modern) | ✅ |
-| 13 | [`modules/13_concurrency_advanced`](modules/13_concurrency_advanced/) | 并发进阶 / Advanced Concurrency | ⚠️ WIP |
-| 14 | [`modules/14_move_semantics_basics`](modules/14_move_semantics_basics/) | Move Semantics Basics | ⚠️ WIP |
-| 15 | [`modules/15_summary`](modules/15_summary/) | 补充与总结 / Supplements & Summary | ⚠️ WIP |
+| 13 | [`modules/13_concurrency_advanced`](modules/13_concurrency_advanced/) | 并发进阶 / Advanced Concurrency | ✅ |
+| 14 | [`modules/14_move_semantics_basics`](modules/14_move_semantics_basics/) | Move Semantics Basics | ✅ |
+| 15 | [`modules/15_summary`](modules/15_summary/) | 补充与总结 / Supplements & Summary | ✅ |

--- a/docs/conan-guide.md
+++ b/docs/conan-guide.md
@@ -685,10 +685,10 @@ CI（[.github/workflows/ci.yml](../.github/workflows/ci.yml)）的 9 路矩阵�
 # matrix include
 - name: linux-gcc-conan
   os: ubuntu-24.04
-  container: ubuntu:25.10
+  container: archlinux:base-devel
   preset: gcc-relwithdebinfo-conan
-  cc: gcc-15
-  cxx: g++-15
+  cc: gcc
+  cxx: g++
   uses-conan: true
   conan-profile: linux-gcc       # <- 仓库 conan/profiles/linux-gcc
   build-type: RelWithDebInfo     # <- 与 preset 后缀对齐

--- a/modules/04_streams_strings/README.md
+++ b/modules/04_streams_strings/README.md
@@ -7,5 +7,50 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/string_basics.cpp` | `std::string` 构造、拼接、查找、子串 |
+| `demos/string_view_demo.cpp` | `std::string_view` 非拥有视图、生命周期注意事项 |
+| `demos/charconv_demo.cpp` | `std::from_chars` / `std::to_chars` 高性能数值转换 |
+| `demos/user_defined_literals.cpp` | 用户自定义字面量 |
+| `demos/format_basics.cpp` | `std::format` 基础用法 |
+| `demos/format_ranges.cpp` | `std::format` 格式化 ranges（C++23） |
+| `demos/print_demo.cpp` | `std::print` / `std::println`（C++23） |
+| `demos/user_defined_format.cpp` | 自定义 `std::formatter` 特化 |
+| `demos/stream_basics.cpp` | `iostream` 基础：`cin` / `cout` / `cerr` |
+| `demos/stream_buffer.cpp` | `streambuf` 与流缓冲 |
+| `demos/spanstream_demo.cpp` | `std::spanstream`（C++23 固定缓冲区流） |
+| `demos/io_manipulators.cpp` | IO 操纵器：`setw` / `setprecision` / `hex` 等 |
+| `demos/regex_demo.cpp` | `std::regex` 正则表达式匹配与搜索 |
+| `demos/fstream_demo.cpp` | `std::fstream` 文件读写 |
+| `demos/stringstream_demo.cpp` | `std::stringstream` 字符串流 |
+| `demos/osyncstream_demo.cpp` | `std::osyncstream` 线程安全输出 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_string.cpp` | `std::string` 构造、修改、查找、比较 |
+| `tests/test_string_view.cpp` | `string_view` 构造、子视图、与 `string` 互操作 |
+| `tests/test_charconv.cpp` | `from_chars` / `to_chars` 整数与浮点往返 |
+| `tests/test_format.cpp` | `std::format` 格式化字符串、对齐、填充 |
+| `tests/test_format_ranges.cpp` | ranges 格式化（C++23） |
+| `tests/test_print.cpp` | `std::print` / `std::println`（C++23） |
+| `tests/test_user_format.cpp` | 自定义 `formatter` 特化 |
+| `tests/test_stream.cpp` | `iostream` 状态、格式标志、`getline` |
+| `tests/test_regex.cpp` | `regex_match` / `regex_search` / `regex_replace` |
+| `tests/test_fstream.cpp` | 文件读写、`tellg` / `seekg` |
+| `tests/test_stringstream.cpp` | `stringstream` 读写、`str()` 提取 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    04_streams_strings__test_string
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 04_streams_strings
+```

--- a/modules/07_value_categories/README.md
+++ b/modules/07_value_categories/README.md
@@ -7,5 +7,35 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/value_categories.cpp` | lvalue / xvalue / prvalue 分类与 `decltype` 判别 |
+| `demos/decltype_demo.cpp` | `decltype` 推导规则：表达式 vs 实体 |
+| `demos/ref_qualifiers.cpp` | 成员函数的 `&` / `&&` 引用限定符 |
+| `demos/deducing_this.cpp` | C++23 deducing this（显式对象形参） |
+| `demos/copy_elision.cpp` | 强制与非强制复制消除 |
+| `demos/rvo_nrvo.cpp` | RVO / NRVO 返回值优化 |
+| `demos/implicit_move.cpp` | 隐式移动（return 局部变量自动移动） |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_value_categories.cpp` | 值类别判别、`decltype` 推导 |
+| `tests/test_ref_qualifiers.cpp` | 引用限定符重载选择 |
+| `tests/test_copy_elision.cpp` | 强制 / 非强制复制消除验证 |
+| `tests/test_rvo.cpp` | RVO / NRVO 消除构造次数 |
+| `tests/test_implicit_move.cpp` | 隐式移动与 `std::move` 对比 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    07_value_categories__test_value_categories
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 07_value_categories
+```

--- a/modules/08_templates_basics/README.md
+++ b/modules/08_templates_basics/README.md
@@ -1,4 +1,4 @@
-# 08_templates_basics — 模板基础与移动语义 / Templates Basics & Move Semantics
+# 08_templates_basics — 模板基础 / Templates Basics
 
 ## 文档 / Docs
 
@@ -7,5 +7,40 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/constexpr_basics.cpp` | `constexpr` 函数与变量、编译期计算 |
+| `demos/consteval_constinit.cpp` | `consteval` 立即函数、`constinit` 静态初始化 |
+| `demos/template_specialization.cpp` | 全特化与偏特化 |
+| `demos/overload_resolution.cpp` | 重载决议规则与模板 vs 非模板优先级 |
+| `demos/constexpr_if.cpp` | `if constexpr` 编译期分支 |
+| `demos/two_phase_lookup.cpp` | 两阶段名查找（dependent / non-dependent） |
+| `demos/typename_template.cpp` | `typename` 与 `template` 消歧义 |
+| `demos/concepts_basics.cpp` | C++20 concepts 基础：requires 子句与约束 |
+| `demos/concept_subsumption.cpp` | concept 包含（subsumption）与约束排序 |
+| `demos/universal_ref.cpp` | 万能引用（转发引用）与完美转发 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_constexpr.cpp` | `constexpr` 函数编译期 / 运行期行为 |
+| `tests/test_specialization.cpp` | 全特化与偏特化选择 |
+| `tests/test_constexpr_if.cpp` | `if constexpr` 分支验证 |
+| `tests/test_concepts.cpp` | concept 约束匹配与拒绝 |
+| `tests/test_concept_subsumption.cpp` | concept 包含关系与重载选择 |
+| `tests/test_universal_ref.cpp` | 万能引用推导与 `std::forward` |
+| `tests/test_ref_collapsing.cpp` | 引用折叠规则 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    08_templates_basics__test_constexpr
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 08_templates_basics
+```

--- a/modules/09_templates_advanced/README.md
+++ b/modules/09_templates_advanced/README.md
@@ -7,5 +7,44 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/template_template_param.cpp` | 模板模板形参 |
+| `demos/nttp_demo.cpp` | 非类型模板形参（NTTP）：整数、浮点、字面量类 |
+| `demos/type_deduction.cpp` | 模板参数推导规则（值 / 引用 / 万能引用） |
+| `demos/ctad_demo.cpp` | 类模板参数推导（CTAD）与自定义推导指引 |
+| `demos/friends_in_templates.cpp` | 模板中的友元声明 |
+| `demos/lazy_instantiation.cpp` | 惰性实例化与未使用成员不实例化 |
+| `demos/variadic_templates.cpp` | 可变参数模板与参数包展开 |
+| `demos/fold_expressions.cpp` | 折叠表达式（C++17） |
+| `demos/sfinae_demo.cpp` | SFINAE 与 `std::enable_if` |
+| `demos/crtp_type_erasure.cpp` | CRTP 静态多态与类型擦除 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_template_template_param.cpp` | 模板模板形参匹配 |
+| `tests/test_nttp.cpp` | NTTP 推导与特化 |
+| `tests/test_type_deduction.cpp` | 模板参数推导验证 |
+| `tests/test_ctad.cpp` | CTAD 推导结果与自定义推导指引 |
+| `tests/test_friends.cpp` | 模板友元的可见性与访问 |
+| `tests/test_lazy_instantiation.cpp` | 惰性实例化行为验证 |
+| `tests/test_variadic.cpp` | 参数包展开与递归终止 |
+| `tests/test_fold.cpp` | 折叠表达式（一元 / 二元、左折 / 右折） |
+| `tests/test_sfinae.cpp` | SFINAE 替换失败与 `enable_if` |
+| `tests/test_crtp.cpp` | CRTP 静态分派 |
+| `tests/test_type_erasure.cpp` | 类型擦除（`std::function` 风格） |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    09_templates_advanced__test_variadic
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 09_templates_advanced
+```

--- a/modules/10_memory/README.md
+++ b/modules/10_memory/README.md
@@ -7,5 +7,42 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/object_layout.cpp` | 对象内存布局、成员对齐、填充 |
+| `demos/alignment_demo.cpp` | `alignof` / `alignas`、过对齐类型 |
+| `demos/new_delete.cpp` | `operator new` / `delete` 重载与类域分配 |
+| `demos/unique_ptr_demo.cpp` | `std::unique_ptr` 独占所有权、自定义删除器 |
+| `demos/shared_ptr_demo.cpp` | `std::shared_ptr` 共享所有权、`make_shared` |
+| `demos/weak_ptr_demo.cpp` | `std::weak_ptr` 打破循环引用 |
+| `demos/pimpl_demo.cpp` | PImpl 惯用法（`unique_ptr` 实现） |
+| `demos/allocator_basics.cpp` | `std::allocator` 接口与自定义分配器 |
+| `demos/pmr_demo.cpp` | `std::pmr` 多态内存资源 |
+| `demos/smart_ptr_adaptors.cpp` | `enable_shared_from_this`、`owner_less`、指针类型转换 |
+| `demos/false_sharing_demo.cpp` | 伪共享与 `hardware_destructive_interference_size` |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_layout.cpp` | 对象布局、sizeof、offsetof |
+| `tests/test_alignment.cpp` | 对齐要求与过对齐分配 |
+| `tests/test_new_delete.cpp` | 类域 `operator new` / `delete` 拦截 |
+| `tests/test_unique_ptr.cpp` | `unique_ptr` 所有权转移、自定义删除器 |
+| `tests/test_shared_ptr.cpp` | `shared_ptr` 引用计数、别名构造 |
+| `tests/test_weak_ptr.cpp` | `weak_ptr` 过期检测、`lock()` |
+| `tests/test_allocator.cpp` | 自定义分配器与容器适配 |
+| `tests/test_pmr.cpp` | PMR 资源切换与内存池 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    10_memory__test_unique_ptr
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 10_memory
+```

--- a/modules/11_error_handling/CMakeLists.txt
+++ b/modules/11_error_handling/CMakeLists.txt
@@ -3,7 +3,7 @@
 # 演示：异常、std::error_code、std::expected（C++23）、断言。
 #
 # std::expected 需要 libstdc++ 12+ / libc++ 16+ / MSVC 17.4+。
-# CI 已经把 Linux 升到 ubuntu:25.10 容器（GCC 15 / Clang 20 + libstdc++-15），
+# CI 已经把 Linux 切到 archlinux:base-devel 容器（滚动发行版，当前 GCC 15.x / Clang 22.x），
 # 标准 stdlib 都能看到 <expected>；保留 try_compile 是为了照顾本地 toolchain
 # 偏旧（如 Ubuntu 24.04 LTS 默认 g++-13）的开发者，工具链不满足时只打印
 # STATUS 并跳过 —— 其余矩阵继续保持绿。

--- a/modules/11_error_handling/README.md
+++ b/modules/11_error_handling/README.md
@@ -7,5 +7,40 @@
 
 ## 内容 / Contents
 
-- Demos: `demos/`
-- Tests: `tests/`
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/optional_basics.cpp` | `std::optional` 可空值语义 |
+| `demos/exception_basics.cpp` | 异常抛出、捕获、标准异常层次 |
+| `demos/exception_safety.cpp` | 异常安全级别（基本 / 强 / 不抛出） |
+| `demos/noexcept_demo.cpp` | `noexcept` 规范与条件 noexcept |
+| `demos/assertion_demo.cpp` | `assert` / `static_assert` |
+| `demos/source_location_demo.cpp` | `std::source_location`（C++20）替代 `__FILE__` / `__LINE__` |
+| `demos/error_code_demo.cpp` | `std::error_code` / `std::error_category` 系统错误码 |
+| `demos/expected_basics.cpp`† | `std::expected`（C++23）值或错误 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_optional.cpp` | `optional` 构造、`value_or`、`transform` |
+| `tests/test_exception.cpp` | 异常捕获顺序、`std::nested_exception` |
+| `tests/test_exception_safety.cpp` | 异常安全保证验证 |
+| `tests/test_noexcept.cpp` | `noexcept` 运算符与函数调用 |
+| `tests/test_source_location.cpp` | `source_location` 捕获正确位置 |
+| `tests/test_error_code.cpp` | 系统错误码比较与消息 |
+| `tests/test_expected.cpp`† | `expected` monadic 操作（`and_then` / `transform` / `or_else`） |
+
+> † 仅在编译器提供 `<expected>` 时构建（libstdc++ 12+ / libc++ 16+ / MSVC 17.4+）。
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    11_error_handling__test_exception
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 11_error_handling
+```

--- a/modules/12_threading/README.md
+++ b/modules/12_threading/README.md
@@ -7,5 +7,42 @@
 
 ## 内容 / Contents
 
-- Demos: `demos/`
-- Tests: `tests/`
+> 整个模块受 `MCPP_HAS_STD_JTHREAD` 守卫（需要 libstdc++ 11+ / MSVC 17.0+ / libc++ 18+）。
+
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/thread_basics.cpp` | `std::thread` 创建、`join` / `detach` |
+| `demos/jthread_basics.cpp` | `std::jthread` 自动 join、协作取消 |
+| `demos/stop_token_demo.cpp` | `std::stop_token` / `stop_source` / `stop_callback` |
+| `demos/mutex_lock_demo.cpp` | `std::mutex` / `lock_guard` / `unique_lock` / `scoped_lock` |
+| `demos/shared_mutex_demo.cpp` | `std::shared_mutex` 读写锁 |
+| `demos/condition_variable_demo.cpp` | `std::condition_variable` 等待通知 |
+| `demos/semaphore_demo.cpp` | `std::counting_semaphore` / `binary_semaphore`（C++20） |
+| `demos/latch_barrier_demo.cpp` | `std::latch` / `std::barrier`（C++20） |
+| `demos/future_promise_demo.cpp` | `std::future` / `std::promise` / `std::async` |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_thread.cpp` | 线程创建与参数传递 |
+| `tests/test_jthread.cpp` | `jthread` 自动 join 与 stop 请求 |
+| `tests/test_stop_token.cpp` | stop 协议、`stop_callback` 触发 |
+| `tests/test_mutex.cpp` | 互斥量与 RAII 锁 |
+| `tests/test_condition_variable.cpp` | 条件变量唤醒与虚假唤醒防护 |
+| `tests/test_semaphore.cpp` | 信号量计数与限流 |
+| `tests/test_latch_barrier.cpp` | latch 一次性屏障 / barrier 可重用屏障 |
+| `tests/test_future_promise.cpp` | `future` / `promise` 值传递与异常传播 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    12_threading__test_jthread
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 12_threading
+```

--- a/modules/13_concurrency_advanced/README.md
+++ b/modules/13_concurrency_advanced/README.md
@@ -7,5 +7,37 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/memory_order_seq_cst.cpp` | `memory_order_seq_cst` 全序一致性 |
+| `demos/memory_order_acq_rel.cpp` | `acquire` / `release` 语义 |
+| `demos/memory_order_relaxed.cpp` | `memory_order_relaxed` 宽松序 |
+| `demos/atomic_operations.cpp` | `std::atomic` 基础操作：load / store / exchange / CAS |
+| `demos/atomic_flag_spinlock.cpp` | `std::atomic_flag` 实现自旋锁 |
+| `demos/atomic_ref_demo.cpp` | `std::atomic_ref`（C++20）非侵入式原子访问 |
+| `demos/fence_demo.cpp` | `std::atomic_thread_fence` 内存栅栏 |
+| `demos/coroutine_basics.cpp` | C++20 协程基础：`co_await` / `co_yield` / `co_return` |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_atomic_basic.cpp` | 原子操作正确性、CAS 循环 |
+| `tests/test_atomic_flag.cpp` | `atomic_flag` 自旋锁互斥性 |
+| `tests/test_atomic_ref.cpp` | `atomic_ref` 对普通变量的原子访问 |
+| `tests/test_memory_order.cpp` | acquire-release 与 relaxed 内存序 |
+| `tests/test_fence.cpp` | 栅栏同步验证 |
+| `tests/test_coroutine.cpp` | 协程挂起 / 恢复 / 结果提取 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    13_concurrency_advanced__test_atomic_basic
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 13_concurrency_advanced
+```

--- a/modules/14_move_semantics_basics/README.md
+++ b/modules/14_move_semantics_basics/README.md
@@ -1,4 +1,4 @@
-# 14_move_semantics_basics — Move Semantics Basics
+# 14_move_semantics_basics — 移动语义基础 / Move Semantics Basics
 
 ## 文档 / Docs
 
@@ -7,5 +7,36 @@
 
 ## 内容 / Contents
 
-> ⚠️ **WIP** — 本模块当前仅有上述文档；`demos/` 与 `tests/` 尚未落地。
-> WIP — only the docs above exist for now; `demos/` and `tests/` are not yet implemented.
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/move_intro.cpp` | 移动语义动机与 `std::move` 基础 |
+| `demos/move_ctor_assign.cpp` | 移动构造函数与移动赋值运算符 |
+| `demos/noexcept_move.cpp` | `noexcept` 移动与 `vector` 重分配优化 |
+| `demos/rule_of_five_zero.cpp` | 五法则 / 零法则 |
+| `demos/moved_from_state.cpp` | moved-from 状态：合法但未指定 |
+| `demos/move_algorithms.cpp` | `std::move` 算法（`<algorithm>` 中的范围移动） |
+| `demos/move_iterators.cpp` | `std::move_iterator` 与 `make_move_iterator` |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_move_ctor.cpp` | 移动构造资源转移验证 |
+| `tests/test_move_assign.cpp` | 移动赋值与自赋值安全 |
+| `tests/test_noexcept_move.cpp` | `noexcept` 对 `vector::push_back` 的影响 |
+| `tests/test_rule_of_five.cpp` | 五法则 / 零法则行为验证 |
+| `tests/test_move_algorithms.cpp` | `std::move` / `std::move_backward` 算法 |
+| `tests/test_move_iterators.cpp` | `move_iterator` 与容器配合 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    14_move_semantics_basics__test_move_ctor
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 14_move_semantics_basics
+```


### PR DESCRIPTION
## Summary

- Fix CI table in README.md: \ubuntu:25.10\ -> \rchlinux:base-devel\, \clang-format-20\/\clang-tidy-20\ -> versionless (LLVM 22.x rolling)
- Update module index: mark all 03-15 modules as completed (were incorrectly labeled WIP)
- Update 8 module READMEs (04/07/08/09/10/13/14): remove stale WIP notice, add detailed demo/test index tables
- Enrich module 11/12 READMEs with full demo/test tables (consistent with 03/05/06/15 style)
- Fix clang-format version recommendation (18+ -> 22+ to match CI)
- Fix Quickstart and conan-guide CI container references
- Expand README layout diagram to reflect actual project structure
- Fix module 11 CMakeLists.txt comment (stale container name)

## Context

A documentation drift audit revealed that README.md and several module READMEs had fallen out of sync with the actual codebase state:
1. CI switched from \ubuntu:25.10\ to \rchlinux:base-devel\ but README was not updated
2. All modules 03-15 now have complete demos+tests but were still marked WIP
3. clang-format version recommendation was outdated (18+ vs required 22+)

## Test plan

- [ ] CI passes (docs-only change; no C++ source modifications)
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)