### PR TITLE
docs: add dual-license (MIT + CC-BY-NC-SA 4.0) and acknowledgement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,16 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Documentation License (modules/*/docs/*.md):
+
+The lecture notes under modules/*/docs/ are derivative works based on the
+"Modern C++ Basics" course by Extra-Creativity
+(https://github.com/Extra-Creativity/Modern-Cpp-Basics),
+licensed under CC-BY-NC-SA 4.0.
+
+These documentation files are therefore also licensed under
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+(CC-BY-NC-SA 4.0): https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/README.md
+++ b/README.md
@@ -455,3 +455,24 @@ GitHub Actions（`.github/workflows/ci.yml`）在每次 push 与 PR 上跑一个
 | 13 | [`modules/13_concurrency_advanced`](modules/13_concurrency_advanced/) | 并发进阶 / Advanced Concurrency | ✅ |
 | 14 | [`modules/14_move_semantics_basics`](modules/14_move_semantics_basics/) | Move Semantics Basics | ✅ |
 | 15 | [`modules/15_summary`](modules/15_summary/) | 补充与总结 / Supplements & Summary | ✅ |
+
+---
+
+## 致谢 / Acknowledgements
+
+本仓库的模块讲义文档（`modules/*/docs/*.md`）基于
+[Extra-Creativity/Modern-Cpp-Basics](https://github.com/Extra-Creativity/Modern-Cpp-Basics)
+课程（作者：Extra-Creativity）的 PDF 课件改写。原课程使用
+[CC-BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) 协议。
+
+---
+
+## 许可证 / License
+
+本仓库采用双协议：
+
+- **代码**（`modules/*/demos/`、`modules/*/tests/`、`cmake/`、`CMakeLists.txt` 等）：
+  [MIT License](LICENSE)
+- **讲义文档**（`modules/*/docs/*.md`）：
+  [CC-BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+  （基于 Extra-Creativity 的 Modern C++ Basics 课程衍生）

--- a/modules/01_basics/README.md
+++ b/modules/01_basics/README.md
@@ -7,5 +7,40 @@
 
 ## 内容 / Contents
 
-- Demos: `demos/`
-- Tests: `tests/`
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/auto_deduction.cpp` | `auto` 类型推导规则、`decltype(auto)` |
+| `demos/integer_safety.cpp` | 定长整型、安全整数比较（`std::cmp_*`） |
+| `demos/bit_ops.cpp` | `<bit>` 辅助函数：`popcount`、`countl_zero`、`bit_ceil` 等 |
+| `demos/literals_and_init.cpp` | 字面量后缀、聚合初始化、指定初始化器 |
+| `demos/enum_scoped.cpp` | 作用域枚举（`enum class`）与底层类型 |
+| `demos/lambdas.cpp` | Lambda 捕获、泛型 lambda、`mutable`、IIFE |
+| `demos/polymorphism.cpp` | 虚函数、`override`、`final`、纯虚 |
+| `demos/spaceship.cpp` | 三路比较运算符（`<=>`）与自动生成的关系运算 |
+| `demos/attributes.cpp` | `[[nodiscard]]`、`[[maybe_unused]]`、`[[deprecated]]`、`[[likely]]` |
+| `demos/control_flow.cpp` | `if constexpr`、`if` 初始化语句、结构化绑定 |
+| `demos/floating_point.cpp` | 浮点精度、`<cfloat>`、NaN / Inf 处理 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_basics.cpp` | auto 推导、整数安全比较、bit 操作、字面量初始化 |
+| `tests/test_lambda.cpp` | Lambda 捕获语义、泛型 lambda、返回值推导 |
+| `tests/test_enum.cpp` | `enum class` 类型安全、底层类型、`std::to_underlying` |
+| `tests/test_polymorphism.cpp` | 虚函数分派、`override` / `final` 保护 |
+| `tests/test_spaceship.cpp` | `<=>` 运算符、`strong_ordering` / `partial_ordering` |
+| `tests/test_floating_point.cpp` | 浮点比较、特殊值（NaN / Inf）行为 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    01_basics__test_basics
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 01_basics
+```

--- a/modules/02_lifetime_type_safety/README.md
+++ b/modules/02_lifetime_type_safety/README.md
@@ -7,5 +7,48 @@
 
 ## 内容 / Contents
 
-- Demos: `demos/`
-- Tests: `tests/`
+### Demos
+
+| 文件 | 主题 |
+| ---- | ---- |
+| `demos/storage_duration.cpp` | 自动 / 静态 / 线程 / 动态存储期 |
+| `demos/lifetime_extension.cpp` | const 引用 / 右值引用延长临时对象生命周期 |
+| `demos/dangling_pitfalls.cpp` | 悬空引用 / 指针的常见陷阱 |
+| `demos/placement_new.cpp` | placement new、显式析构、`std::launder` |
+| `demos/storage_reuse.cpp` | 存储复用、`start_lifetime_as`（C++23） |
+| `demos/byte_storage.cpp` | `std::byte` / `unsigned char` 缓冲区与严格别名 |
+| `demos/slicing.cpp` | 对象切片问题与 `clone()` 模式 |
+| `demos/multiple_inheritance.cpp` | 多重继承、`using` 声明消歧义 |
+| `demos/virtual_inheritance.cpp` | 菱形继承与虚继承 |
+| `demos/mixin_pattern.cpp` | CRTP 混入模式 |
+| `demos/casts_overview.cpp` | `static_cast` / `const_cast` / `reinterpret_cast` / `std::bit_cast` |
+| `demos/dynamic_cast_rtti.cpp` | `dynamic_cast` 与 RTTI（`typeid` / `type_index`） |
+| `demos/variant_visit.cpp` | `std::variant` + `std::visit` 类型安全联合 |
+| `demos/any_demo.cpp` | `std::any` 类型擦除容器 |
+
+### Tests
+
+| 文件 | 覆盖点 |
+| ---- | ---- |
+| `tests/test_lifetime.cpp` | 存储期、生命周期开始 / 结束规则 |
+| `tests/test_lifetime_extension.cpp` | 临时对象延寿场景与失效场景 |
+| `tests/test_placement_new.cpp` | placement new 正确性、`std::launder` 必要性 |
+| `tests/test_storage_reuse.cpp` | 存储复用与隐式生命周期类型 |
+| `tests/test_aliasing.cpp` | 严格别名规则、`std::byte` / `memcpy` 安全访问 |
+| `tests/test_slicing.cpp` | 切片行为验证、值语义 vs 引用语义 |
+| `tests/test_inheritance.cpp` | 多重继承、虚继承、混入模式 |
+| `tests/test_casts.cpp` | 四种 cast 正确使用与 `bit_cast` |
+| `tests/test_dynamic_cast.cpp` | `dynamic_cast` 成功 / 失败（指针返回 null / 引用抛异常） |
+| `tests/test_variant.cpp` | `variant` 构造、`visit`、`get_if`、`valueless_by_exception` |
+| `tests/test_any.cpp` | `any` 存取、`any_cast`、类型擦除边界 |
+
+## 运行 / Run
+
+```bash
+# 构建本模块的某个测试（任选一个 preset）
+cmake --build --preset gcc-debug --target \
+    02_lifetime_type_safety__test_lifetime
+
+# 跑本模块全部测试
+ctest --preset gcc-debug -L 02_lifetime_type_safety
+```


### PR DESCRIPTION
## Summary

- Add CC-BY-NC-SA 4.0 license clause to LICENSE for documentation files (\modules/*/docs/*.md\), which are derivative works based on [Extra-Creativity/Modern-Cpp-Basics](https://github.com/Extra-Creativity/Modern-Cpp-Basics)
- Add Acknowledgements and License sections to README.md explaining the dual-license scheme
- Complete module 01_basics and 02_lifetime_type_safety READMEs with detailed demo/test index tables (was just \- Demos: demos/\)

## Context

The lecture notes under \modules/*/docs/\ are derived from the Modern C++ Basics course which uses CC-BY-NC-SA 4.0. The code (demos, tests, cmake) is original work and remains MIT. This PR makes the licensing situation explicit and compliant.

## Test plan

- [ ] CI passes (docs-only change, no C++ source modifications)
- [ ] LICENSE and README render correctly on GitHub

Made with [Cursor](https://cursor.com)